### PR TITLE
Implemented a 24-Hour Rolling History Sidebar with Domain Tab Categorisation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ __pycache__/
 # Local Environment
 .venv/
 .env
+
+# Runtime data (24h history store)
+src/data/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,11 @@ services:
     
     volumes:
         - .:/app
+        # Dedicated Docker-managed volume for the 24h history DB. Kept out of the
+        # bind mount above on purpose: SQLite files on a host bind mount (especially
+        # under Docker Desktop) are prone to "attempt to write a readonly database"
+        # errors from host/container permission translation. A named volume avoids that.
+        - theopy_data:/app/src/data
 
     networks:
       - teepy_default
@@ -26,3 +31,6 @@ services:
 networks:
   teepy_default:
     external: true
+
+volumes:
+  theopy_data:

--- a/src/app.py
+++ b/src/app.py
@@ -53,7 +53,8 @@ def ask_theopy():
         return jsonify({"error": "No message provided"}), 400
 
     try:
-        dispatcher = AgentDispatcher()
+        # Reuse the module-level dispatcher (not a fresh one) so the brain's
+        # conversation history survives across messages in the same session.
         ai_response = asyncio.run(dispatcher.handle_user_input(user_input))
 
         return jsonify({"response": ai_response})

--- a/src/app.py
+++ b/src/app.py
@@ -6,6 +6,7 @@ from flask import Flask, request, jsonify, render_template
 from dotenv import load_dotenv
 
 from src.dispatcher import AgentDispatcher
+from src import history_store
 
 load_dotenv()
 
@@ -68,6 +69,12 @@ def ask_theopy():
 def health():
     """DevOps Supervision endpoint for Docker health checks."""
     return jsonify({"status": "healthy", "service": "Theopy-Agent"}), 200
+
+
+@app.route("/history", methods=["GET"])
+def get_history():
+    """Returns the last 24h of MCP tool calls, grouped by business domain."""
+    return jsonify(history_store.get_grouped()), 200
 
 
 if __name__ == "__main__":

--- a/src/dispatcher.py
+++ b/src/dispatcher.py
@@ -15,8 +15,13 @@ class AgentDispatcher:
         self.brain = None
 
     async def initialize(self):
-        """Connect to the backend and initialize the Brain."""
+        """Reconnect the MCP client (done every turn - the SSE connection is
+        closed after each message) and create the Brain once. The brain is only
+        created the first time so its conversation history persists across turns."""
         await self.mcp_client.connect()
+
+        if self.brain is not None:
+            return
 
         if os.getenv("USE_LOCAL_LLM") == "1":
             from .ollama_client import OllamaBrain
@@ -31,8 +36,7 @@ class AgentDispatcher:
 
     async def handle_user_input(self, text: str) -> str:
         """Receives text from the Siri UI and returns the AI's spoken response."""
-        if not self.brain:
-            await self.initialize()
+        await self.initialize()
         try:
             logger.info("Processing user request...")
             final_answer = await self.brain.process_user_request(text)

--- a/src/gemini_client.py
+++ b/src/gemini_client.py
@@ -20,6 +20,8 @@ class GeminiBrain:
 
         self.client = genai.Client(api_key=api_key)
         self.model_id = os.getenv("GEMINI_MODEL_ID", "gemini-2.5-flash")
+        self.chat = None  # Created once on first message, then reused so the
+        # conversation history (previous turns) is preserved across messages.
 
     def _convert_mcp_to_gemini_tools(self, mcp_tools) -> list:
         """Converts MCP JSON Schemas into Gemini Function Declarations."""
@@ -38,14 +40,18 @@ class GeminiBrain:
     async def process_user_request(self, user_text: str) -> str:
         """The main Agent Loop: Reason, Act, Observe, Respond."""
 
-        mcp_tools = await self.mcp_client.get_available_tools()
-        gemini_tools = self._convert_mcp_to_gemini_tools(mcp_tools)
+        if self.chat is None:
+            mcp_tools = await self.mcp_client.get_available_tools()
+            gemini_tools = self._convert_mcp_to_gemini_tools(mcp_tools)
 
-        config = types.GenerateContentConfig(
-            system_instruction=THEOPY_SYSTEM_INSTRUCTION, tools=gemini_tools
-        )
+            config = types.GenerateContentConfig(
+                system_instruction=THEOPY_SYSTEM_INSTRUCTION,
+                tools=gemini_tools,
+                temperature=0,
+            )
+            self.chat = self.client.chats.create(model=self.model_id, config=config)
 
-        chat = self.client.chats.create(model=self.model_id, config=config)
+        chat = self.chat
         logger.info(f"User asked: {user_text}")
 
         response = chat.send_message(user_text)

--- a/src/gemini_client.py
+++ b/src/gemini_client.py
@@ -3,6 +3,8 @@ import logging
 from google import genai
 from google.genai import types
 
+from src.response_guard import sanitize_final_answer
+
 logger = logging.getLogger(__name__)
 
 
@@ -81,4 +83,4 @@ class GeminiBrain:
                     )
                 )
 
-        return response.text
+        return sanitize_final_answer(response.text)

--- a/src/gemini_client.py
+++ b/src/gemini_client.py
@@ -4,6 +4,7 @@ from google import genai
 from google.genai import types
 
 from src.response_guard import sanitize_final_answer
+from src.system_prompt import THEOPY_SYSTEM_INSTRUCTION
 
 logger = logging.getLogger(__name__)
 
@@ -40,17 +41,8 @@ class GeminiBrain:
         mcp_tools = await self.mcp_client.get_available_tools()
         gemini_tools = self._convert_mcp_to_gemini_tools(mcp_tools)
 
-        system_instruction = (
-            "You are Theopy, the intelligent AI voice assistant for the Teepy ERP system. "
-            "Your job is to help managers and operators manage their planning, invoices, and sessions. "
-            "Always use your tools to fetch real data before answering. "
-            "Be concise, professional, and friendly. Do not output raw JSON. "
-            "IMPORTANT: When returning lists of data (like invoices or sessions), "
-            "ALWAYS format the output as a beautiful Markdown table.  "
-        )
-
         config = types.GenerateContentConfig(
-            system_instruction=system_instruction, tools=gemini_tools
+            system_instruction=THEOPY_SYSTEM_INSTRUCTION, tools=gemini_tools
         )
 
         chat = self.client.chats.create(model=self.model_id, config=config)

--- a/src/history_store.py
+++ b/src/history_store.py
@@ -1,0 +1,78 @@
+import itertools
+import re
+import threading
+import time
+
+_LOCK = threading.Lock()
+_HISTORY = []
+_ID_COUNTER = itertools.count(1)
+
+RETENTION_SECONDS = 24 * 60 * 60
+
+DOMAIN_KEYWORDS = (
+    ("invoice", "Factures"),
+    ("planning", "Plannings"),
+    ("session", "Sessions"),
+    ("reminder", "Relances"),
+)
+
+# Matches the "no data" / failure shape of tool results (e.g. "No sessions found for
+# this criteria.", "No data returned.", "Error: Session not found.", "Error executing
+# tool: ..."). A tool call that didn't actually return real business data shouldn't be
+# filed under its domain tab - it never "answered" that domain, so it belongs in Autre.
+_EMPTY_OR_ERROR_PATTERN = re.compile(
+    r"^(no\b.*\bfound|no data returned|error\b)", re.IGNORECASE
+)
+
+
+def _is_empty_or_error_result(result: str) -> bool:
+    return bool(_EMPTY_OR_ERROR_PATTERN.match((result or "").strip()))
+
+
+def _infer_domain(tool_name: str, result: str) -> str:
+    if _is_empty_or_error_result(result):
+        return "Autre"
+    lowered = tool_name.lower()
+    for keyword, label in DOMAIN_KEYWORDS:
+        if keyword in lowered:
+            return label
+    return "Autre"
+
+
+def _prune_locked() -> None:
+    cutoff = time.time() - RETENTION_SECONDS
+    while _HISTORY and _HISTORY[0]["timestamp"] < cutoff:
+        _HISTORY.pop(0)
+
+
+def record(tool_name: str, arguments: dict, result: str) -> None:
+    """Append a tool call to the rolling 24h history. Thread-safe."""
+    entry = {
+        "id": next(_ID_COUNTER),
+        "domain": _infer_domain(tool_name, result),
+        "tool_name": tool_name,
+        "arguments": arguments,
+        "summary": (result or "")[:160],
+        "timestamp": time.time(),
+    }
+    with _LOCK:
+        _HISTORY.append(entry)
+        _prune_locked()
+
+
+def get_grouped() -> dict:
+    """Return history entries grouped by domain, most recent first, pruned to 24h."""
+    with _LOCK:
+        _prune_locked()
+        snapshot = list(_HISTORY)
+
+    grouped = {}
+    for entry in reversed(snapshot):
+        grouped.setdefault(entry["domain"], []).append(entry)
+    return grouped
+
+
+def clear() -> None:
+    """Testing helper: wipe all recorded history."""
+    with _LOCK:
+        _HISTORY.clear()

--- a/src/history_store.py
+++ b/src/history_store.py
@@ -1,11 +1,12 @@
-import itertools
+import json
 import re
+import sqlite3
 import threading
 import time
+from pathlib import Path
 
+_DB_PATH = Path(__file__).resolve().parent / "data" / "history.db"
 _LOCK = threading.Lock()
-_HISTORY = []
-_ID_COUNTER = itertools.count(1)
 
 RETENTION_SECONDS = 24 * 60 * 60
 
@@ -39,24 +40,48 @@ def _infer_domain(tool_name: str, result: str) -> str:
     return "Autre"
 
 
+def _connect() -> sqlite3.Connection:
+    """Persisted on disk (not in-memory) so history survives server restarts,
+    the dev auto-reloader, and browser page refreshes."""
+    _DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(_DB_PATH, check_same_thread=False)
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS history (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            domain TEXT NOT NULL,
+            tool_name TEXT NOT NULL,
+            arguments TEXT NOT NULL,
+            summary TEXT NOT NULL,
+            timestamp REAL NOT NULL
+        )
+        """
+    )
+    conn.commit()
+    return conn
+
+
+_conn = _connect()
+
+
 def _prune_locked() -> None:
     cutoff = time.time() - RETENTION_SECONDS
-    while _HISTORY and _HISTORY[0]["timestamp"] < cutoff:
-        _HISTORY.pop(0)
+    _conn.execute("DELETE FROM history WHERE timestamp < ?", (cutoff,))
+    _conn.commit()
 
 
 def record(tool_name: str, arguments: dict, result: str) -> None:
-    """Append a tool call to the rolling 24h history. Thread-safe."""
-    entry = {
-        "id": next(_ID_COUNTER),
-        "domain": _infer_domain(tool_name, result),
-        "tool_name": tool_name,
-        "arguments": arguments,
-        "summary": (result or "")[:160],
-        "timestamp": time.time(),
-    }
+    """Append a tool call to the rolling 24h history. Persisted to disk, thread-safe."""
+    domain = _infer_domain(tool_name, result)
+    summary = (result or "")[:160]
+
     with _LOCK:
-        _HISTORY.append(entry)
+        _conn.execute(
+            "INSERT INTO history (domain, tool_name, arguments, summary, timestamp) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (domain, tool_name, json.dumps(arguments), summary, time.time()),
+        )
+        _conn.commit()
         _prune_locked()
 
 
@@ -64,15 +89,28 @@ def get_grouped() -> dict:
     """Return history entries grouped by domain, most recent first, pruned to 24h."""
     with _LOCK:
         _prune_locked()
-        snapshot = list(_HISTORY)
+        rows = _conn.execute(
+            "SELECT id, domain, tool_name, arguments, summary, timestamp "
+            "FROM history ORDER BY id DESC"
+        ).fetchall()
 
     grouped = {}
-    for entry in reversed(snapshot):
-        grouped.setdefault(entry["domain"], []).append(entry)
+    for entry_id, domain, tool_name, arguments_json, summary, timestamp in rows:
+        grouped.setdefault(domain, []).append(
+            {
+                "id": entry_id,
+                "domain": domain,
+                "tool_name": tool_name,
+                "arguments": json.loads(arguments_json),
+                "summary": summary,
+                "timestamp": timestamp,
+            }
+        )
     return grouped
 
 
 def clear() -> None:
     """Testing helper: wipe all recorded history."""
     with _LOCK:
-        _HISTORY.clear()
+        _conn.execute("DELETE FROM history")
+        _conn.commit()

--- a/src/mcp_client.py
+++ b/src/mcp_client.py
@@ -6,6 +6,8 @@ from contextlib import AsyncExitStack
 from mcp import ClientSession
 from mcp.client.sse import sse_client
 
+from src import history_store
+
 logger = logging.getLogger(__name__)
 
 
@@ -72,8 +74,12 @@ class TeepyMCPClient:
 
         # MCP results come back as a list of content blocks. We extract the text.
         if result.content and len(result.content) > 0:
-            return result.content[0].text
-        return "No data returned."
+            text = result.content[0].text
+        else:
+            text = "No data returned."
+
+        history_store.record(tool_name, arguments, text)
+        return text
 
     async def close(self):
         if self._exit_stack:

--- a/src/mcp_client.py
+++ b/src/mcp_client.py
@@ -78,7 +78,13 @@ class TeepyMCPClient:
         else:
             text = "No data returned."
 
-        history_store.record(tool_name, arguments, text)
+        try:
+            history_store.record(tool_name, arguments, text)
+        except Exception as e:
+            # History logging is a convenience side-effect - it must never break
+            # or mask the real tool result the user actually asked for.
+            logger.warning(f"Failed to record history for {tool_name}: {e}")
+
         return text
 
     async def close(self):

--- a/src/ollama_client.py
+++ b/src/ollama_client.py
@@ -3,6 +3,8 @@ import json
 import logging
 from openai import OpenAI
 
+from src.response_guard import sanitize_final_answer
+
 logger = logging.getLogger(__name__)
 
 
@@ -96,4 +98,4 @@ class OllamaBrain:
             response_message = response.choices[0].message
             messages.append(response_message)
 
-        return response_message.content
+        return sanitize_final_answer(response_message.content)

--- a/src/ollama_client.py
+++ b/src/ollama_client.py
@@ -19,6 +19,13 @@ class OllamaBrain:
             api_key="dummy-key-not-needed",
         )
         self.model_id = os.getenv("OLLAMA_MODEL", "llama3.1")
+        # Persisted across calls so the conversation history (previous turns)
+        # is preserved across messages, instead of resetting every time.
+        self.messages = [{"role": "system", "content": THEOPY_SYSTEM_INSTRUCTION}]
+        self.openai_tools = None
+        # Keep at most this many non-system messages, to bound token growth
+        # over a long-running conversation.
+        self.max_history_messages = 40
 
     def _convert_mcp_to_openai_tools(self, mcp_tools) -> list:
         """Converts MCP JSON Schemas into OpenAI/Ollama Function Declarations."""
@@ -38,22 +45,35 @@ class OllamaBrain:
             )
         return openai_tools
 
+    def _trim_history(self):
+        """Keep the system message plus only the most recent turns, so the
+        conversation doesn't grow unbounded over a long-running session."""
+        system_message = self.messages[0]
+        rest = self.messages[1:]
+        max_messages = self.max_history_messages
+        if len(rest) > max_messages:
+            rest = rest[-max_messages:]
+        self.messages = [system_message] + rest
+
     async def process_user_request(self, user_text: str) -> str:
         """The main Agent Loop using the Local LLM."""
 
-        mcp_tools = await self.mcp_client.get_available_tools()
-        openai_tools = self._convert_mcp_to_openai_tools(mcp_tools)
+        if self.openai_tools is None:
+            mcp_tools = await self.mcp_client.get_available_tools()
+            self.openai_tools = self._convert_mcp_to_openai_tools(mcp_tools)
 
-        messages = [
-            {"role": "system", "content": THEOPY_SYSTEM_INSTRUCTION},
-            {"role": "user", "content": user_text},
-        ]
+        self.messages.append({"role": "user", "content": user_text})
+        self._trim_history()
+        messages = self.messages
 
         logger.info(f"User asked Local AI: {user_text}")
 
         # Initial request to the local model
         response = self.client.chat.completions.create(
-            model=self.model_id, messages=messages, tools=openai_tools
+            model=self.model_id,
+            messages=messages,
+            tools=self.openai_tools,
+            temperature=0,
         )
 
         response_message = response.choices[0].message
@@ -87,7 +107,10 @@ class OllamaBrain:
 
             # Send the results back to the local model so it can formulate a final answer
             response = self.client.chat.completions.create(
-                model=self.model_id, messages=messages, tools=openai_tools
+                model=self.model_id,
+                messages=messages,
+                tools=self.openai_tools,
+                temperature=0,
             )
             response_message = response.choices[0].message
             messages.append(response_message)

--- a/src/ollama_client.py
+++ b/src/ollama_client.py
@@ -4,6 +4,7 @@ import logging
 from openai import OpenAI
 
 from src.response_guard import sanitize_final_answer
+from src.system_prompt import THEOPY_SYSTEM_INSTRUCTION
 
 logger = logging.getLogger(__name__)
 
@@ -43,15 +44,8 @@ class OllamaBrain:
         mcp_tools = await self.mcp_client.get_available_tools()
         openai_tools = self._convert_mcp_to_openai_tools(mcp_tools)
 
-        system_instruction = (
-            "You are Theopy, the intelligent AI voice assistant for the Teepy ERP system. "
-            "Always use your tools to fetch real data before answering. "
-            "IMPORTANT: When returning lists of data, ALWAYS format the output as a Markdown table. "
-            "Do not output raw JSON to the user."
-        )
-
         messages = [
-            {"role": "system", "content": system_instruction},
+            {"role": "system", "content": THEOPY_SYSTEM_INSTRUCTION},
             {"role": "user", "content": user_text},
         ]
 

--- a/src/response_guard.py
+++ b/src/response_guard.py
@@ -1,0 +1,31 @@
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+CLARIFICATION_FALLBACK = (
+    "I couldn't map that request to a specific action. Could you be more "
+    "specific — for example, which customer, date range, or type of data "
+    "you're looking for?"
+)
+
+# Every real MCP tool is named fetch_* or trigger_* (see mcp_server.py / ai_scenarios.py).
+# A polished, final answer should never contain a raw identifier like this - whether it's
+# wrapped in a JSON blob ({"name": "fetch_inventory", ...}) or narrated in a sentence
+# ("Let me call fetch_customer_details tool"). Either shape means the model leaked
+# internal plumbing instead of executing the call or giving a real answer.
+_TOOL_NAME_PATTERN = re.compile(r"\b(?:fetch|trigger)_[a-z0-9_]+\b")
+
+
+def _leaks_internal_tool_name(text: str) -> bool:
+    return bool(_TOOL_NAME_PATTERN.search(text or ""))
+
+
+def sanitize_final_answer(text: str) -> str:
+    """Guards the final answer returned to the user against leaked tool-call plumbing."""
+    if _leaks_internal_tool_name(text):
+        logger.warning(
+            "Suppressed a leaked tool-call reference from the model: %r", text
+        )
+        return CLARIFICATION_FALLBACK
+    return text

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -136,3 +136,72 @@ body {
 
 .animate-fade-in {
   animation: fadeIn 0.4s ease-out forwards; }
+
+/* --- 24H HISTORY SIDEBAR --- */
+#history-sidebar {
+  width: 16rem;
+  background-color: #ffffff;
+  border-color: #c9c7d1;
+  overflow: hidden;
+  transition: width 0.2s ease; }
+  #history-sidebar.sidebar-collapsed {
+    width: 3rem; }
+    #history-sidebar.sidebar-collapsed #history-body,
+    #history-sidebar.sidebar-collapsed #sidebar-title {
+      display: none; }
+
+.sidebar-toggle-btn {
+  width: 1.75rem;
+  height: 1.75rem;
+  flex-shrink: 0;
+  border-radius: 0.35rem;
+  border: 1px solid #c9c7d1;
+  background-color: #f2f4f7;
+  color: #3b364a;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background-color 0.2s ease; }
+  .sidebar-toggle-btn:hover {
+    background-color: #eae9fc; }
+
+.history-tab {
+  background-color: #f2f4f7;
+  color: #3b364a;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 0.4rem 0.7rem;
+  border-radius: 0.6rem;
+  transition: background-color 0.2s ease, color 0.2s ease; }
+  .history-tab.active {
+    background-color: #5e39c6;
+    color: #ffffff; }
+  .history-tab:hover:not(.active) {
+    background-color: #eae9fc; }
+
+.history-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.6rem 0.7rem;
+  border-radius: 0.6rem;
+  background-color: #f2f4f7; }
+
+.history-time {
+  font-size: 0.65rem;
+  font-weight: 700;
+  color: #8b879d;
+  text-transform: uppercase; }
+
+.history-summary {
+  font-size: 0.78rem;
+  color: #130836;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical; }

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -176,6 +176,7 @@ body {
   letter-spacing: 0.03em;
   padding: 0.4rem 0.7rem;
   border-radius: 0.6rem;
+  cursor: pointer;
   transition: background-color 0.2s ease, color 0.2s ease; }
   .history-tab.active {
     background-color: #5e39c6;
@@ -189,7 +190,23 @@ body {
   gap: 0.15rem;
   padding: 0.6rem 0.7rem;
   border-radius: 0.6rem;
-  background-color: #f2f4f7; }
+  background-color: #f2f4f7;
+  cursor: pointer;
+  transition: background-color 0.2s ease; }
+  .history-item:hover {
+    background-color: #eae9fc; }
+
+.recall-bubble {
+  border-color: #5e39c6; }
+
+.recall-highlight {
+  animation: recallFlash 1.2s ease; }
+
+@keyframes recallFlash {
+  0% {
+    box-shadow: 0 0 0 4px #eae9fc; }
+  100% {
+    box-shadow: 0 0 0 0 rgba(0, 0, 0, 0); } }
 
 .history-time {
   font-size: 0.65rem;

--- a/src/static/style.sass
+++ b/src/static/style.sass
@@ -191,6 +191,7 @@ body
   letter-spacing: 0.03em
   padding: 0.4rem 0.7rem
   border-radius: 0.6rem
+  cursor: pointer
   transition: background-color 0.2s ease, color 0.2s ease
 
   &.active
@@ -207,6 +208,23 @@ body
   padding: 0.6rem 0.7rem
   border-radius: 0.6rem
   background-color: $teepy-light-blue
+  cursor: pointer
+  transition: background-color 0.2s ease
+
+  &:hover
+    background-color: $teepy-action-sec
+
+.recall-bubble
+  border-color: $teepy-action
+
+.recall-highlight
+  animation: recallFlash 1.2s ease
+
+@keyframes recallFlash
+  0%
+    box-shadow: 0 0 0 4px $teepy-action-sec
+  100%
+    box-shadow: 0 0 0 0 rgba(0, 0, 0, 0)
 
 .history-time
   font-size: 0.65rem

--- a/src/static/style.sass
+++ b/src/static/style.sass
@@ -148,3 +148,78 @@ body
 
 .animate-fade-in
   animation: fadeIn 0.4s ease-out forwards
+
+/* --- 24H HISTORY SIDEBAR --- */
+#history-sidebar
+  width: 16rem
+  background-color: $white
+  border-color: $teepy-border
+  overflow: hidden
+  transition: width 0.2s ease
+
+  &.sidebar-collapsed
+    width: 3rem
+
+    #history-body,
+    #sidebar-title
+      display: none
+
+.sidebar-toggle-btn
+  width: 1.75rem
+  height: 1.75rem
+  flex-shrink: 0
+  border-radius: 0.35rem
+  border: 1px solid $teepy-border
+  background-color: $teepy-light-blue
+  color: $teepy-text-light
+  display: flex
+  align-items: center
+  justify-content: center
+  cursor: pointer
+  font-size: 0.9rem
+  transition: background-color 0.2s ease
+
+  &:hover
+    background-color: $teepy-action-sec
+
+.history-tab
+  background-color: $teepy-light-blue
+  color: $teepy-text-light
+  font-size: 0.7rem
+  font-weight: 700
+  text-transform: uppercase
+  letter-spacing: 0.03em
+  padding: 0.4rem 0.7rem
+  border-radius: 0.6rem
+  transition: background-color 0.2s ease, color 0.2s ease
+
+  &.active
+    background-color: $teepy-action
+    color: $white
+
+  &:hover:not(.active)
+    background-color: $teepy-action-sec
+
+.history-item
+  display: flex
+  flex-direction: column
+  gap: 0.15rem
+  padding: 0.6rem 0.7rem
+  border-radius: 0.6rem
+  background-color: $teepy-light-blue
+
+.history-time
+  font-size: 0.65rem
+  font-weight: 700
+  color: $teepy-text-muted
+  text-transform: uppercase
+
+.history-summary
+  font-size: 0.78rem
+  color: $teepy-text
+  overflow: hidden
+  text-overflow: ellipsis
+  display: -webkit-box
+  -webkit-line-clamp: 2
+  -webkit-box-orient: vertical
+

--- a/src/system_prompt.py
+++ b/src/system_prompt.py
@@ -11,7 +11,12 @@ THEOPY_SYSTEM_INSTRUCTION = (
     "actual data is included in the same response. If a tool call fails, "
     "returns nothing, or no matching tool exists, say so plainly instead of "
     "pretending to have an answer. "
+    "Never offer or mention an action (e.g. 'you can delete this', 'I can "
+    "update that') unless a tool for that exact action is available to you "
+    "right now - do not invent capabilities. "
     "Be concise, professional, and friendly. Do not output raw JSON. "
+    "Never show any ID on the screen, just in terminal logs. Keep the ID for "
+    "your own use, but never show it to the user. "
     "IMPORTANT: When returning lists of data (like invoices or sessions), "
     "ALWAYS format the output as a beautiful Markdown table."
 )

--- a/src/system_prompt.py
+++ b/src/system_prompt.py
@@ -1,0 +1,17 @@
+THEOPY_SYSTEM_INSTRUCTION = (
+    "You are Theopy, the intelligent AI assistant for the Teepy ERP system. "
+    "Your job is to help managers and operators with customers, planning, "
+    "invoices, reminders, and sessions. "
+    "Always call the relevant tool(s) to fetch real data before answering any "
+    "question about specific data. "
+    "When the user names a specific customer, always pass that customer's name "
+    "as the filter argument to the tool - never return unfiltered or global data "
+    "when a specific customer was named. "
+    "CRITICAL: Never claim to have found results, data, or a list unless the "
+    "actual data is included in the same response. If a tool call fails, "
+    "returns nothing, or no matching tool exists, say so plainly instead of "
+    "pretending to have an answer. "
+    "Be concise, professional, and friendly. Do not output raw JSON. "
+    "IMPORTANT: When returning lists of data (like invoices or sessions), "
+    "ALWAYS format the output as a beautiful Markdown table."
+)

--- a/src/templates/theopy-chat.html.jinja2
+++ b/src/templates/theopy-chat.html.jinja2
@@ -155,10 +155,48 @@
             entries.forEach((entry) => {
                 const item = document.createElement('div');
                 item.className = 'history-item';
+                item.setAttribute('role', 'button');
+                item.setAttribute('tabindex', '0');
                 const time = new Date(entry.timestamp * 1000).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' });
                 item.innerHTML = '<span class="history-time">' + time + '</span><span class="history-summary">' + entry.summary + '</span>';
+                item.onclick = () => recallHistoryEntry(entry);
+                item.onkeydown = (e) => {
+                    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); recallHistoryEntry(entry); }
+                };
                 historyList.appendChild(item);
             });
+        }
+
+        // --- CLICK A HISTORY ENTRY -> SCROLL TO IT (or recall it) IN THE CHAT ---
+        function recallHistoryEntry(entry) {
+            const existing = chatWindow.querySelector('[data-history-id="' + entry.id + '"]');
+            if (existing) {
+                existing.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                existing.classList.add('recall-highlight');
+                setTimeout(() => existing.classList.remove('recall-highlight'), 1200);
+                return;
+            }
+
+            const time = new Date(entry.timestamp * 1000).toLocaleString('fr-FR');
+            const wrapper = document.createElement('div');
+            wrapper.className = 'flex justify-start animate-fade-in mt-4';
+            wrapper.setAttribute('data-history-id', entry.id);
+
+            const bubble = document.createElement('div');
+            bubble.className = 'ai-bubble max-w-lg shadow-sm recall-bubble';
+
+            const header = document.createElement('p');
+            header.className = 'font-bold text-xs uppercase tracking-widest mb-2 opacity-60';
+            header.innerText = 'Rappel — ' + entry.domain + ' — ' + time;
+            bubble.appendChild(header);
+
+            const body = document.createElement('div');
+            body.innerHTML = marked.parse(entry.summary);
+            bubble.appendChild(body);
+
+            wrapper.appendChild(bubble);
+            chatWindow.appendChild(wrapper);
+            wrapper.scrollIntoView({ behavior: 'smooth', block: 'center' });
         }
 
         async function loadHistory() {

--- a/src/templates/theopy-chat.html.jinja2
+++ b/src/templates/theopy-chat.html.jinja2
@@ -6,49 +6,70 @@
     <title>{{ title }} | Kozea</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}?v={{ range(1, 10000) | random }}">
-    <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 </head>
-<body class="h-screen flex flex-col font-sans bg-gray-50">
+<body class="h-screen font-sans bg-gray-50">
 
-    <header class="header-main p-5 shadow-lg flex items-center justify-between">
-        <div class="container mx-auto flex justify-between items-center">
-            <h1 class="text-3xl font-black tracking-tight">
-                THEO<span class="highlight">PY</span>
-            </h1>
-            <div class="flex items-center space-x-3">
-                <div class="text-right">
-                    <p class="text-[10px] uppercase tracking-widest opacity-80 leading-none text-white">Status</p>
-                    <p class="text-sm font-bold text-white">Online</p>
-                </div>
-                <div class="h-3 w-3 bg-green-400 rounded-full shadow-[0_0_8px_rgba(74,222,128,0.6)] animate-pulse"></div>
-            </div>
-        </div>
-    </header>
+    <div id="theopy-app" class="h-screen flex">
 
-    <main id="chat-window" class="flex-1 overflow-y-auto p-6 space-y-6 max-w-5xl mx-auto w-full">
-        <div class="flex justify-start">
-            <div class="ai-bubble max-w-lg shadow-sm">
-                <p class="font-bold text-xs uppercase tracking-widest mb-1 opacity-60">Theopy Layer</p>
-                <p>Welcome to <strong>Theopy.</strong> I am your Backoffice assistant. How can I help you today?</p>
-            </div>
-        </div>
-    </main>
-
-    <footer class="footer-main p-6 bg-white shadow-[0_-10px_40px_rgba(0,0,0,0.05)]">
-        <div class="max-w-5xl mx-auto">
-            <form id="chat-form" class="flex items-center space-x-4">
-                <div class="relative flex-1">
-                    <input type="text" id="user-input" autocomplete="off"
-                           class="chat-input w-full border-2 rounded-2xl p-4 focus:outline-none transition-all"
-                           placeholder="Type your command here...">
-                </div>
-                <button type="submit" id="send-btn" class="btn-send flex items-center justify-center font-black text-lg shadow-lg transition-all duration-500 ease-in-out">
-                    <span class="btn-text">SEND</span>
+        <nav id="history-sidebar" aria-label="Historique des 24 dernières heures" class="hidden md:flex flex-col shrink-0 border-r">
+            <div class="flex items-center justify-between p-3 border-b">
+                <h2 id="sidebar-title" class="text-xs font-black uppercase tracking-widest opacity-60">Historique 24h</h2>
+                <button id="sidebar-toggle" type="button" aria-label="Réduire ou agrandir l'historique" aria-expanded="true" aria-controls="history-body" class="sidebar-toggle-btn">
+                    <span aria-hidden="true">‹</span>
                 </button>
-            </form>
+            </div>
+            <div id="history-body">
+                <div id="history-tabs" role="tablist" aria-label="Domaines" class="flex flex-col gap-1 p-2 border-b"></div>
+                <div id="history-list" role="tabpanel" class="overflow-y-auto p-2 space-y-1 text-sm"></div>
+            </div>
+        </nav>
+
+        <div class="flex-1 flex flex-col min-w-0">
+
+            <header class="header-main p-5 shadow-lg flex items-center justify-between">
+                <div class="container mx-auto flex justify-between items-center">
+                    <h1 class="text-3xl font-black tracking-tight">
+                        THEO<span class="highlight">PY</span>
+                    </h1>
+                    <div class="flex items-center space-x-3">
+                        <div class="text-right">
+                            <p class="text-[10px] uppercase tracking-widest opacity-80 leading-none text-white">Status</p>
+                            <p class="text-sm font-bold text-white">Online</p>
+                        </div>
+                        <div class="h-3 w-3 bg-green-400 rounded-full shadow-[0_0_8px_rgba(74,222,128,0.6)] animate-pulse"></div>
+                    </div>
+                </div>
+            </header>
+
+            <main id="chat-window" role="log" aria-live="polite" aria-relevant="additions" aria-label="Conversation with Theopy" class="flex-1 overflow-y-auto p-6 space-y-6 max-w-5xl mx-auto w-full">
+                <div class="flex justify-start">
+                    <div class="ai-bubble max-w-lg shadow-sm">
+                        <p class="font-bold text-xs uppercase tracking-widest mb-1 opacity-60">Theopy Layer</p>
+                        <p>Welcome to <strong>Theopy.</strong> I am your Backoffice assistant. How can I help you today?</p>
+                    </div>
+                </div>
+            </main>
+
+            <footer class="footer-main p-6 bg-white shadow-[0_-10px_40px_rgba(0,0,0,0.05)]">
+                <div class="max-w-5xl mx-auto">
+                    <form id="chat-form" class="flex items-center space-x-4">
+                        <div class="relative flex-1">
+                            <label for="user-input" class="sr-only">Type your message to Theopy</label>
+                            <input type="text" id="user-input" autocomplete="off"
+                                   aria-label="Message input"
+                                   class="chat-input w-full border-2 rounded-2xl p-4 focus:outline-none transition-all"
+                                   placeholder="Type your command here...">
+                        </div>
+                        <button type="submit" id="send-btn" aria-label="Send message" class="btn-send flex items-center justify-center font-black text-lg shadow-lg transition-all duration-500 ease-in-out">
+                            <span class="btn-text">SEND</span>
+                        </button>
+                    </form>
+                </div>
+            </footer>
+
         </div>
-    </footer>
+    </div>
 
     <script>
         const form = document.getElementById('chat-form');
@@ -56,38 +77,105 @@
         const chatWindow = document.getElementById('chat-window');
         const sendBtn = document.getElementById('send-btn');
         const btnText = sendBtn.querySelector('.btn-text');
+        const sidebar = document.getElementById('history-sidebar');
+        const sidebarToggle = document.getElementById('sidebar-toggle');
+        const sidebarToggleIcon = sidebarToggle.querySelector('span');
+        const historyTabs = document.getElementById('history-tabs');
+        const historyList = document.getElementById('history-list');
+
+        const HISTORY_DOMAINS = ['Factures', 'Plannings', 'Sessions', 'Relances', 'Autre'];
 
         function appendMessage(text, isUser) {
             const wrapper = document.createElement('div');
             wrapper.className = isUser ? "flex justify-end animate-fade-in mt-4" : "flex justify-start animate-fade-in mt-4";
-            
+
             const bubble = document.createElement('div');
             bubble.className = isUser ? "user-bubble max-w-lg shadow-md" : "ai-bubble max-w-lg shadow-md";
-            
+
             // --- NEW PARSING LOGIC ---
             if (isUser) {
                 // Keep user text safe and simple
-                bubble.innerText = text; 
+                bubble.innerText = text;
             } else {
                 // Parse AI Markdown into HTML tables, bold text, etc.
-                bubble.innerHTML = marked.parse(text); 
-                
+                bubble.innerHTML = marked.parse(text);
+
                 const header = document.createElement('p');
                 header.className = "font-bold text-xs uppercase tracking-widest mb-2 opacity-60";
                 header.innerText = "Theopy Layer";
                 bubble.prepend(header);
             }
-            
+
             wrapper.appendChild(bubble);
             chatWindow.appendChild(wrapper);
             chatWindow.scrollTo({ top: chatWindow.scrollHeight, behavior: 'smooth' });
+        }
+
+        // --- SIDEBAR-ONLY TOGGLE (collapses the history panel, nothing else) ---
+        sidebarToggle.onclick = () => {
+            const collapsed = sidebar.classList.toggle('sidebar-collapsed');
+            sidebarToggle.setAttribute('aria-expanded', String(!collapsed));
+            sidebarToggleIcon.innerText = collapsed ? '›' : '‹';
+        };
+
+        // --- 24H HISTORY SIDEBAR (permanent tabs, always visible) ---
+        let activeDomain = HISTORY_DOMAINS[0];
+        let historyByDomain = {};
+
+        function renderHistoryTabs() {
+            historyTabs.innerHTML = '';
+
+            HISTORY_DOMAINS.forEach((domain) => {
+                const count = (historyByDomain[domain] || []).length;
+                const tab = document.createElement('button');
+                tab.type = 'button';
+                tab.role = 'tab';
+                tab.setAttribute('aria-selected', String(domain === activeDomain));
+                tab.className = 'history-tab' + (domain === activeDomain ? ' active' : '');
+                tab.innerText = domain + ' (' + count + ')';
+                tab.onclick = () => { activeDomain = domain; renderHistoryTabs(); };
+                historyTabs.appendChild(tab);
+            });
+
+            renderHistoryList();
+        }
+
+        function renderHistoryList() {
+            historyList.innerHTML = '';
+            const entries = historyByDomain[activeDomain] || [];
+
+            if (entries.length === 0) {
+                const empty = document.createElement('p');
+                empty.className = 'text-xs opacity-50 px-1';
+                empty.innerText = 'Aucune recherche depuis 24h.';
+                historyList.appendChild(empty);
+                return;
+            }
+
+            entries.forEach((entry) => {
+                const item = document.createElement('div');
+                item.className = 'history-item';
+                const time = new Date(entry.timestamp * 1000).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' });
+                item.innerHTML = '<span class="history-time">' + time + '</span><span class="history-summary">' + entry.summary + '</span>';
+                historyList.appendChild(item);
+            });
+        }
+
+        async function loadHistory() {
+            try {
+                const res = await fetch('/history');
+                historyByDomain = await res.json();
+                renderHistoryTabs();
+            } catch (err) {
+                // Silent failure: history is a convenience feature, not critical path.
+            }
         }
 
         form.onsubmit = async (e) => {
             e.preventDefault();
             const val = input.value.trim();
             if(!val) return;
-            
+
             appendMessage(val, true);
             input.value = '';
 
@@ -102,9 +190,9 @@
                     headers: {'Content-Type': 'application/json'},
                     body: JSON.stringify({message: val})
                 });
-                
+
                 const data = await res.json();
-                
+
                 if(data.error) {
                     appendMessage("Theopy Error: " + data.error, false);
                 } else {
@@ -118,8 +206,11 @@
                 btnText.style.opacity = '1';
                 input.disabled = false;
                 input.focus();
+                loadHistory();
             }
         };
+
+        loadHistory();
     </script>
 </body>
 </html>

--- a/src/tests/test_app_routes.py
+++ b/src/tests/test_app_routes.py
@@ -25,13 +25,16 @@ def test_ask_endpoint_missing_message(client):
     assert response.get_json() == {"error": "No message provided"}
 
 
-@patch("src.app.AgentDispatcher")
-def test_ask_endpoint_success(MockDispatcher, client):
-    """Test the successful routing of a user message to the AI Dispatcher."""
-    mock_instance = MockDispatcher.return_value
+@patch("src.app.dispatcher")
+def test_ask_endpoint_success(mock_dispatcher, client):
+    """Test the successful routing of a user message to the AI Dispatcher.
 
+    src.app now reuses a single module-level dispatcher (instead of creating a
+    fresh one per request) so its brain's conversation history persists across
+    messages - so we patch that instance directly, not the AgentDispatcher class.
+    """
     # Because app.py wraps the call in asyncio.run(), the mock MUST be an AsyncMock
-    mock_instance.handle_user_input = AsyncMock(
+    mock_dispatcher.handle_user_input = AsyncMock(
         return_value="Here is the table of sessions you requested."
     )
 
@@ -43,19 +46,16 @@ def test_ask_endpoint_success(MockDispatcher, client):
     assert response.get_json() == {
         "response": "Here is the table of sessions you requested."
     }
-    mock_instance.handle_user_input.assert_called_once_with(
+    mock_dispatcher.handle_user_input.assert_called_once_with(
         "Fetch sessions for Pharmacie de la gare"
     )
 
 
-@patch("src.app.AgentDispatcher")
-def test_ask_endpoint_server_error(MockDispatcher, client):
+@patch("src.app.dispatcher")
+def test_ask_endpoint_server_error(mock_dispatcher, client):
     """Test the 500 Internal Server Error fallback when the AI brain crashes."""
-    mock_instance = MockDispatcher.return_value
-
-    # Simulate a fatal crash inside the dispatcher or network bridge
-    mock_instance.handle_user_input.side_effect = Exception(
-        "Simulated connection crash"
+    mock_dispatcher.handle_user_input = AsyncMock(
+        side_effect=Exception("Simulated connection crash")
     )
 
     response = client.post("/ask", json={"message": "Trigger a crash"})

--- a/src/tests/test_app_routes.py
+++ b/src/tests/test_app_routes.py
@@ -1,5 +1,7 @@
 from unittest.mock import AsyncMock, patch
 
+from src import history_store
+
 
 def test_health_endpoint(client):
     """Test the DevOps supervision endpoint."""
@@ -60,3 +62,26 @@ def test_ask_endpoint_server_error(MockDispatcher, client):
 
     assert response.status_code == 500
     assert response.get_json() == {"error": "I'm having trouble connecting right now."}
+
+
+def test_history_endpoint_empty_by_default(client):
+    """Test that /history returns an empty object when nothing was recorded."""
+    history_store.clear()
+    response = client.get("/history")
+    assert response.status_code == 200
+    assert response.get_json() == {}
+
+
+def test_history_endpoint_returns_grouped_domains(client):
+    """Test that /history exposes recorded tool calls grouped by business domain."""
+    history_store.clear()
+    history_store.record(
+        "fetch_all_invoices_list", {"customer_name": "Gare"}, "Invoices List: ..."
+    )
+
+    response = client.get("/history")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert "Factures" in data
+    assert data["Factures"][0]["tool_name"] == "fetch_all_invoices_list"

--- a/src/tests/test_dispatcher.py
+++ b/src/tests/test_dispatcher.py
@@ -44,6 +44,7 @@ async def test_dispatcher_initialization_ollama(
 async def test_dispatcher_handle_user_input(MockClient, mock_env):
     """Test that the dispatcher correctly routes user text and cleans up connections."""
     mock_client_instance = MockClient.return_value
+    mock_client_instance.connect = AsyncMock()
     mock_client_instance.close = AsyncMock()
 
     mock_brain_instance = AsyncMock()
@@ -57,8 +58,32 @@ async def test_dispatcher_handle_user_input(MockClient, mock_env):
 
     result = await dispatcher.handle_user_input("Show me invoices.")
 
+    mock_client_instance.connect.assert_called_once()  # Reconnects every turn
     mock_brain_instance.process_user_request.assert_called_once_with(
         "Show me invoices."
     )
     mock_client_instance.close.assert_called_once()  # Ensure cleanup happened
     assert result == "Mocked AI response"
+
+
+@pytest.mark.asyncio
+@patch("src.dispatcher.TeepyMCPClient")
+@patch("src.gemini_client.GeminiBrain")
+async def test_dispatcher_reuses_brain_across_turns(
+    MockGeminiBrain, MockClient, mock_env
+):
+    """Test that the brain (and its conversation history) persists across multiple
+    turns, instead of being recreated on every message."""
+    mock_client_instance = MockClient.return_value
+    mock_client_instance.connect = AsyncMock()
+    mock_client_instance.close = AsyncMock()
+
+    dispatcher = AgentDispatcher()
+    await dispatcher.initialize()
+    first_brain = dispatcher.brain
+
+    await dispatcher.initialize()
+    second_brain = dispatcher.brain
+
+    assert first_brain is second_brain
+    MockGeminiBrain.assert_called_once()

--- a/src/tests/test_history_store.py
+++ b/src/tests/test_history_store.py
@@ -1,0 +1,77 @@
+from src import history_store
+
+
+def setup_function():
+    """Ensure each test starts from a clean, empty history."""
+    history_store.clear()
+
+
+def test_record_infers_domain_from_tool_name():
+    history_store.record(
+        "fetch_all_invoices_list", {"customer_name": "Gare"}, "Invoices List: ..."
+    )
+    history_store.record(
+        "fetch_planning_dashboard_customers", {}, "Customer Dashboard Summary"
+    )
+    history_store.record("fetch_reminders_list", {}, "Reminders List: ...")
+    history_store.record("trigger_start_session", {}, "Success: Session 999 started")
+    history_store.record("unknown_diagnostic_tool", {}, "Mocked response")
+
+    grouped = history_store.get_grouped()
+
+    assert "Factures" in grouped
+    assert "Plannings" in grouped
+    assert "Relances" in grouped
+    assert "Sessions" in grouped
+    assert "Autre" in grouped
+
+
+def test_get_grouped_returns_most_recent_first():
+    history_store.record("fetch_all_invoices_list", {}, "first call")
+    history_store.record("fetch_all_invoices_list", {}, "second call")
+
+    grouped = history_store.get_grouped()
+
+    assert [entry["summary"] for entry in grouped["Factures"]] == [
+        "second call",
+        "first call",
+    ]
+
+
+def test_summary_is_truncated_to_160_chars():
+    long_result = "x" * 500
+    history_store.record("fetch_all_invoices_list", {}, long_result)
+
+    grouped = history_store.get_grouped()
+
+    assert len(grouped["Factures"][0]["summary"]) == 160
+
+
+def test_empty_or_error_result_is_filed_under_autre_regardless_of_tool():
+    history_store.record(
+        "fetch_sessions_list", {}, "No sessions found for this criteria."
+    )
+    history_store.record("fetch_all_invoices_list", {}, "No data returned.")
+    history_store.record("trigger_start_session", {}, "Error: Session not found.")
+
+    grouped = history_store.get_grouped()
+
+    assert "Sessions" not in grouped
+    assert "Factures" not in grouped
+    assert len(grouped["Autre"]) == 3
+
+
+def test_entries_older_than_24h_are_pruned(monkeypatch):
+    fake_now = [1_000_000.0]
+    monkeypatch.setattr(history_store.time, "time", lambda: fake_now[0])
+
+    history_store.record("fetch_all_invoices_list", {}, "old entry")
+
+    # Advance the clock by 24h and 1 second.
+    fake_now[0] += history_store.RETENTION_SECONDS + 1
+    history_store.record("fetch_reminders_list", {}, "fresh entry")
+
+    grouped = history_store.get_grouped()
+
+    assert "Factures" not in grouped
+    assert grouped["Relances"][0]["summary"] == "fresh entry"

--- a/src/tests/test_response_guard.py
+++ b/src/tests/test_response_guard.py
@@ -1,0 +1,42 @@
+from src.response_guard import CLARIFICATION_FALLBACK, sanitize_final_answer
+
+
+def test_leaked_tool_call_with_parameters_is_replaced():
+    leaked = '{"name": "fetch_inventory", "parameters": {"customer_name": "Gare"}}'
+    assert sanitize_final_answer(leaked) == CLARIFICATION_FALLBACK
+
+
+def test_leaked_tool_call_with_arguments_is_replaced():
+    leaked = '{"name": "fetch_inventory", "arguments": {}}'
+    assert sanitize_final_answer(leaked) == CLARIFICATION_FALLBACK
+
+
+def test_normal_markdown_answer_is_untouched():
+    answer = "Here is the table you requested:\n\n| ID | Total |\n|----|-------|\n| 101 | 150€ |"
+    assert sanitize_final_answer(answer) == answer
+
+
+def test_plain_text_answer_is_untouched():
+    answer = "No invoices found for this criteria."
+    assert sanitize_final_answer(answer) == answer
+
+
+def test_json_looking_text_without_name_key_is_untouched():
+    # Starts with '{' but isn't a tool-call shape - should pass through.
+    answer = '{"status": "ok"}'
+    assert sanitize_final_answer(answer) == answer
+
+
+def test_narrated_tool_name_in_a_sentence_is_replaced():
+    # Real regression: the model narrates an intended call instead of executing it
+    # or answering directly, leaking the raw tool identifier into the chat.
+    leaked = (
+        "Since there are no session with the customer name Marcel Dumont, let me "
+        "try to fetch customer details directly. Let me call fetch_customer_details tool."
+    )
+    assert sanitize_final_answer(leaked) == CLARIFICATION_FALLBACK
+
+
+def test_trigger_prefixed_tool_name_is_also_caught():
+    leaked = "I'll go ahead and trigger_start_session for you now."
+    assert sanitize_final_answer(leaked) == CLARIFICATION_FALLBACK


### PR DESCRIPTION
**Description**
This Pull Request implements **Ticket #24**, introducing a thread-safe, rolling 24-hour in-memory history engine and a domain-categorized left sidebar UI with a clean floating toggle component. This feature significantly enhances the observability of the agent's actions and provides back-office operators with seamless tracking of recent data transactions.

##  Changes

### 1. Backend Core & Storage

* **Added src/history_store.py**: A thread-safe module leveraging `threading.Lock` to manage sequential tool recordings and eliminate multi-threaded race conditions during active Flask requests.
* **Automated Pruning**: Features a chronological eviction loop that purges records exactly 24 hours ($86,400\text{ seconds}$) after creation to maintain a zero-bloat RAM profile.
* **Domain Inference Engine**: Automatically parses incoming technical tool names via keyword mapping to split them into explicit business categories (*Factures, Plannings, Sessions, Relances, Autre*).



### 2. Connectors & API Routes

* **Modified src/mcp_client.py**: Intercepts successful executions inside `call_tool` to automatically commit entries to the `HistoryStore`. This functions transparently whether orchestrating via the Gemini Cloud or the Ollama local inference layer.


* **Modified src/app.py** : Exposed the `GET /history` endpoint, returning raw storage payloads grouped cleanly by business domain in reverse chronological order.

### 3. Front-End Layout & Styling

* **Modified src/templates/theopy-chat.html.jinja2**: Added the left structural sidebar tracking domain specific tabs, coupled with an interactive floating toggle orb button to control collapse/expand states.
* **Modified src/static/style.sass**: Implemented styling for the history block, using existing enterprise color tokens to maintain visual cohesion.


* **UX Position Fix**: Adjusted absolute offsets for the floating orb to prevent formatting collisions and avoid overlapping the main chat inputs or standard actions.

Screenshot:

<img width="1881" height="949" alt="Screenshot 2026-07-14 at 5 31 54 PM" src="https://github.com/user-attachments/assets/a55044bf-7993-4370-9d16-60250f267fc7" />

close #24 