### PR TITLE
Add login/logout and per-user session isolation

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,18 +1,83 @@
+import logging
 import os
 import sass
+import threading
 import traceback
 import asyncio
-from flask import Flask, request, jsonify, render_template
+from functools import wraps
+
+import requests
+from flask import (
+    Flask,
+    request,
+    jsonify,
+    render_template,
+    redirect,
+    session,
+    url_for,
+)
 from dotenv import load_dotenv
 
+from src.auth import TeepyAuthError, authenticate_with_teepy
 from src.dispatcher import AgentDispatcher
 from src import history_store
 
 load_dotenv()
 
-app = Flask(__name__)
+logger = logging.getLogger(__name__)
 
-dispatcher = AgentDispatcher()
+app = Flask(__name__)
+# Falls back to a fixed dev value so test/CI environments (no .env file) don't
+# fail at import time - real deployments set SECRET_KEY via .env. Session
+# forgery isn't the primary defense boundary here anyway: every MCP tool call
+# is re-authorized against Teepy's own database on the server side.
+app.secret_key = os.getenv("SECRET_KEY", "dev-insecure-default-change-in-production")
+
+# One AgentDispatcher per logged-in Teepy user_id, not a single shared
+# instance - each dispatcher owns a brain with its own conversation history
+# and its own role-filtered tool list, so different users of this Theopy
+# instance never see each other's chat or a stale/wrong tool set.
+_dispatchers: dict[int, AgentDispatcher] = {}
+_dispatchers_lock = threading.Lock()
+
+
+def _get_dispatcher_for(user_id: int) -> AgentDispatcher:
+    with _dispatchers_lock:
+        if user_id not in _dispatchers:
+            _dispatchers[user_id] = AgentDispatcher()
+        return _dispatchers[user_id]
+
+
+def _discard_dispatcher_for(user_id: int) -> None:
+    """Drop a logged-out user's dispatcher, closing its MCP connection and
+    freeing its conversation history/tool cache."""
+    with _dispatchers_lock:
+        stale_dispatcher = _dispatchers.pop(user_id, None)
+
+    if stale_dispatcher is None:
+        return
+
+    try:
+        asyncio.run(stale_dispatcher.shutdown())
+    except Exception as e:
+        logger.warning(
+            f"Failed to cleanly shut down dispatcher for user_id={user_id}: {e}"
+        )
+
+
+def login_required(view):
+    """Gate a route behind a logged-in Theopy session. /ask is an AJAX
+    endpoint, so it gets a JSON 401 instead of a redirect."""
+
+    @wraps(view)
+    def wrapped(*args, **kwargs):
+        if "user_id" not in session:
+            if request.path == "/ask":
+                return jsonify({"error": "Not authenticated"}), 401
+            return redirect(url_for("login"))
+        return view(*args, **kwargs)
+
+    return wrapped
 
 
 def compile_sass():
@@ -39,12 +104,74 @@ compile_sass()
 # --- ROUTES ---
 
 
+@app.route("/login", methods=["GET", "POST"])
+def login():
+    if request.method == "GET":
+        if "user_id" in session:
+            return redirect(url_for("index"))
+        return render_template("login.html.jinja2")
+
+    login_value = request.form.get("login", "").strip()
+    password = request.form.get("password", "")
+
+    if not login_value or not password:
+        return (
+            render_template(
+                "login.html.jinja2",
+                error="Identifiant et mot de passe requis.",
+                login=login_value,
+            ),
+            400,
+        )
+
+    try:
+        profile = authenticate_with_teepy(login_value, password)
+    except TeepyAuthError as e:
+        return (
+            render_template("login.html.jinja2", error=str(e), login=login_value),
+            401,
+        )
+    except requests.RequestException:
+        return (
+            render_template(
+                "login.html.jinja2",
+                error="Impossible de contacter Teepy. Réessayez plus tard.",
+                login=login_value,
+            ),
+            503,
+        )
+
+    session["user_id"] = profile["user_id"]
+    session["login"] = profile["login"]
+    session["name"] = profile["name"]
+    session["role"] = profile["role"]
+
+    return redirect(url_for("index"))
+
+
+@app.route("/logout")
+def logout():
+    user_id = session.get("user_id")
+    session.clear()
+    if user_id is not None:
+        _discard_dispatcher_for(user_id)
+    return redirect(url_for("login"))
+
+
 @app.route("/")
+@login_required
 def index():
-    return render_template("theopy-chat.html.jinja2", title="Theopy AI")
+    return render_template(
+        "theopy-chat.html.jinja2",
+        title="Theopy AI",
+        user_name=session.get("name"),
+        user_login=session.get("login"),
+        user_role=session.get("role"),
+    )
 
 
 @app.route("/ask", methods=["POST"])
+@login_required
 def ask_theopy():
     """The bridge between the Frontend UI and the AI Dispatcher."""
     user_input = request.json.get("message")
@@ -53,9 +180,15 @@ def ask_theopy():
         return jsonify({"error": "No message provided"}), 400
 
     try:
-        # Reuse the module-level dispatcher (not a fresh one) so the brain's
-        # conversation history survives across messages in the same session.
-        ai_response = asyncio.run(dispatcher.handle_user_input(user_input))
+        # Reuse this user's own dispatcher (not a fresh one) so the brain's
+        # conversation history survives across messages in the same session,
+        # without leaking into any other logged-in user's dispatcher.
+        dispatcher = _get_dispatcher_for(session["user_id"])
+        ai_response = asyncio.run(
+            dispatcher.handle_user_input(
+                user_input, session["user_id"], session["role"]
+            )
+        )
 
         return jsonify({"response": ai_response})
 
@@ -73,6 +206,7 @@ def health():
 
 
 @app.route("/history", methods=["GET"])
+@login_required
 def get_history():
     """Returns the last 24h of MCP tool calls, grouped by business domain."""
     return jsonify(history_store.get_grouped()), 200

--- a/src/auth.py
+++ b/src/auth.py
@@ -1,0 +1,31 @@
+import os
+
+import requests
+
+TEEPY_API_URL = os.getenv("TEEPY_API_URL", "http://teepy-app-1:5000")
+
+
+class TeepyAuthError(Exception):
+    """Raised when Teepy rejects the login/password or the account can't use
+    Theopy (wrong credentials, inactive account, employee role)."""
+
+
+def authenticate_with_teepy(login: str, password: str) -> dict:
+    """POST credentials to Teepy's dedicated /api/theopy/authenticate endpoint
+    and return the caller's profile (user_id, login, name, role) on success.
+
+    Raises TeepyAuthError with Teepy's own message on a 400/401/403 response.
+    Network/connection failures propagate as requests.RequestException - the
+    caller is expected to tell that apart from bad credentials.
+    """
+    response = requests.post(
+        f"{TEEPY_API_URL}/api/theopy/authenticate",
+        json={"login": login, "password": password},
+        timeout=5,
+    )
+
+    if response.status_code == 200:
+        return response.json()
+
+    error_message = response.json().get("error", "Authentication failed.")
+    raise TeepyAuthError(error_message)

--- a/src/dispatcher.py
+++ b/src/dispatcher.py
@@ -34,9 +34,17 @@ class AgentDispatcher:
             self.brain = GeminiBrain(self.mcp_client)
             print("🧠 Booting Theopy with CLOUD GEMINI Model")
 
-    async def handle_user_input(self, text: str) -> str:
-        """Receives text from the Siri UI and returns the AI's spoken response."""
+    async def handle_user_input(self, text: str, user_id: int, role: str) -> str:
+        """Receives text from the chat UI and returns the AI's spoken response.
+
+        user_id is the Teepy user_id from the logged-in Flask session - it is
+        carried on every MCP tool call so Teepy can enforce the real caller's
+        role, never trusted from anything the LLM itself reports. role is used
+        only to filter the tool list shown to the LLM (a UX nicety - see
+        src/role_access.py); Teepy's own server-side check is authoritative."""
         await self.initialize()
+        self.mcp_client.current_user_id = user_id
+        self.mcp_client.current_user_role = role
         try:
             logger.info("Processing user request...")
             final_answer = await self.brain.process_user_request(text)

--- a/src/mcp_client.py
+++ b/src/mcp_client.py
@@ -7,6 +7,7 @@ from mcp import ClientSession
 from mcp.client.sse import sse_client
 
 from src import history_store
+from src.role_access import filter_tools_for_role
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +21,13 @@ class TeepyMCPClient:
         self.teepy_mcp_url = os.getenv("TEEPY_MCP_URL", "http://127.0.0.1:5001/sse")
         self._session = None
         self._exit_stack = None
+        # Set by AgentDispatcher before each turn, from the logged-in Flask
+        # session - never from the LLM. Carried on call_tool()'s `meta`, the
+        # only channel Teepy's role enforcement trusts as the real caller.
+        self.current_user_id = None
+        # Set once per session by AgentDispatcher, used only to filter the
+        # tool list shown to the LLM (UX nicety - see src/role_access.py).
+        self.current_user_role = None
         # Set by the brain at the start of each turn, so tool calls made during
         # that turn can be tagged with the question that triggered them.
         self.current_question = None
@@ -65,7 +73,7 @@ class TeepyMCPClient:
                     "inputSchema": tool.inputSchema,
                 }
             )
-        return formatted_tools
+        return filter_tools_for_role(formatted_tools, self.current_user_role)
 
     async def call_tool(self, tool_name: str, arguments: dict) -> str:
         """Execute a specific tool on the Teepy server and return the string result."""
@@ -73,7 +81,12 @@ class TeepyMCPClient:
             raise RuntimeError("MCP Client is not connected.")
 
         logger.info(f"Calling tool: {tool_name} with args: {arguments}")
-        result = await self._session.call_tool(tool_name, arguments)
+        meta = (
+            {"theopy_user_id": self.current_user_id}
+            if self.current_user_id is not None
+            else None
+        )
+        result = await self._session.call_tool(tool_name, arguments, meta=meta)
 
         # MCP results come back as a list of content blocks. We extract the text.
         if result.content and len(result.content) > 0:

--- a/src/role_access.py
+++ b/src/role_access.py
@@ -1,0 +1,72 @@
+"""Client-side mirror of Teepy's mcp_tools/*.py `_ALLOWED_ROLES` tuples.
+
+This is a UX nicety only, not a security boundary: Teepy's own requires_role()
+re-checks every call server-side regardless of what's filtered here, so this
+map drifting out of sync creates a UX gap (a tool shown that gets denied, or
+hidden when it would have been allowed), never a security gap. Keep it in
+sync by hand whenever a tool is added, removed, or reassigned on the Teepy side.
+"""
+
+TOOL_ALLOWED_ROLES: dict[str, tuple[str, ...]] = {
+    # invoices.py
+    "fetch_all_invoices_list": ("administrator", "manager", "commercial"),
+    "fetch_global_invoice_summary": ("administrator", "manager", "commercial"),
+    "fetch_pending_unit_lines": ("administrator", "manager", "commercial"),
+    "fetch_mark_invoice_status": ("administrator", "manager", "commercial"),
+    "fetch_single_invoice": ("administrator", "manager", "commercial"),
+    "trigger_generate_invoices": ("administrator",),
+    # customers.py
+    "fetch_customers_list": ("administrator", "manager", "commercial"),
+    "fetch_single_customer": ("administrator", "manager", "commercial"),
+    "fetch_customer_company": ("administrator", "manager", "commercial"),
+    "fetch_customer_360": ("administrator", "manager", "commercial"),
+    # plannings.py
+    "fetch_planning_dashboard_operators": ("administrator", "manager", "operator"),
+    "fetch_planning_operators": ("administrator", "manager", "operator"),
+    "fetch_planning_dashboard_customers": ("administrator", "manager", "operator"),
+    # sessions.py
+    "fetch_sessions_list": ("administrator", "manager", "operator", "contractor"),
+    "fetch_customer_sessions": ("administrator", "manager", "operator", "contractor"),
+    "trigger_start_session": ("administrator", "manager", "operator", "contractor"),
+    "fetch_edit_session": ("administrator", "manager", "operator", "contractor"),
+    "fetch_current_session": ("administrator", "manager", "operator", "contractor"),
+    "fetch_session_lines": ("administrator", "manager", "operator", "contractor"),
+    "fetch_session_line_details": (
+        "administrator",
+        "manager",
+        "operator",
+        "contractor",
+    ),
+    "trigger_add_session_line": (
+        "administrator",
+        "manager",
+        "operator",
+        "contractor",
+    ),
+    "trigger_edit_session_line": (
+        "administrator",
+        "manager",
+        "operator",
+        "contractor",
+    ),
+    "fetch_monthly_summary": ("administrator", "manager", "operator", "contractor"),
+    "trigger_close_session": ("administrator", "manager", "operator", "contractor"),
+    "trigger_letters_add": ("administrator", "manager", "operator", "contractor"),
+    "fetch_letter_pdf": ("administrator", "manager", "operator", "contractor"),
+    "fetch_preview_pdf": ("administrator", "manager", "operator", "contractor"),
+    "fetch_attachment_pdf": ("administrator", "manager", "operator", "contractor"),
+    # reminders.py
+    "fetch_reminders_list": ("administrator", "manager", "commercial"),
+    "trigger_add_reminder": ("administrator", "manager", "commercial"),
+    "trigger_edit_reminder": ("administrator", "manager", "commercial"),
+    "trigger_treat_reminder": ("administrator", "manager", "commercial"),
+}
+
+
+def filter_tools_for_role(tools: list[dict], role: str | None) -> list[dict]:
+    """Keep only the tools this role is allowed to use. A tool missing from
+    TOOL_ALLOWED_ROLES (a forgotten update) or a missing role is excluded by
+    default - deny-by-default, matching Teepy's own requires_role()."""
+    if role is None:
+        return []
+    return [tool for tool in tools if role in TOOL_ALLOWED_ROLES.get(tool["name"], ())]

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -297,3 +297,87 @@ body {
   border-radius: 0.6rem;
   padding: 0.5rem 0.9rem;
   cursor: not-allowed; }
+
+/* --- ACCOUNT SECTION (settings sidebar, logged-in state) --- */
+.settings-account-name {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #130836; }
+
+.settings-account-role {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: #5e39c6; }
+
+.settings-logout-btn {
+  display: inline-block;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: #ffffff;
+  background-color: #f76f5b;
+  border: none;
+  border-radius: 0.6rem;
+  padding: 0.5rem 0.9rem;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background-color 0.2s ease; }
+  .settings-logout-btn:hover {
+    background-color: #f54d34; }
+
+/* --- LOGIN PAGE --- */
+.login-card {
+  width: 100%;
+  max-width: 22rem;
+  background-color: #ffffff;
+  border: 1px solid #c9c7d1;
+  border-radius: 1rem;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.08);
+  padding: 2.5rem 2rem; }
+
+.login-subtitle {
+  font-size: 0.8rem;
+  color: #8b879d;
+  text-align: center;
+  margin-bottom: 1.5rem; }
+
+.login-error {
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: #c1292e;
+  background-color: #fef3e5;
+  border-radius: 0.6rem;
+  padding: 0.6rem 0.8rem;
+  margin-bottom: 1rem; }
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem; }
+
+.login-label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #3b364a;
+  margin-top: 0.6rem; }
+
+.login-input {
+  border: 1px solid #c9c7d1;
+  background-color: #f2f4f7;
+  color: #130836;
+  border-radius: 0.6rem;
+  padding: 0.7rem 0.9rem;
+  font-size: 0.9rem; }
+  .login-input:focus {
+    outline: none;
+    border-color: #5e39c6;
+    box-shadow: 0 0 0 3px #eae9fc; }
+
+.login-submit {
+  margin-top: 1.5rem;
+  width: 100%;
+  height: auto;
+  padding: 0.85rem; }

--- a/src/static/style.sass
+++ b/src/static/style.sass
@@ -318,3 +318,89 @@ body
   padding: 0.5rem 0.9rem
   cursor: not-allowed
 
+/* --- ACCOUNT SECTION (settings sidebar, logged-in state) --- */
+.settings-account-name
+  font-size: 0.85rem
+  font-weight: 700
+  color: $teepy-text
+
+.settings-account-role
+  font-size: 0.7rem
+  font-weight: 700
+  text-transform: uppercase
+  letter-spacing: 0.03em
+  color: $teepy-action
+
+.settings-logout-btn
+  display: inline-block
+  font-size: 0.78rem
+  font-weight: 700
+  color: $white
+  background-color: $teepy-alert
+  border: none
+  border-radius: 0.6rem
+  padding: 0.5rem 0.9rem
+  cursor: pointer
+  text-decoration: none
+  transition: background-color 0.2s ease
+
+  &:hover
+    background-color: darken($teepy-alert, 8%)
+
+/* --- LOGIN PAGE --- */
+.login-card
+  width: 100%
+  max-width: 22rem
+  background-color: $white
+  border: 1px solid $teepy-border
+  border-radius: 1rem
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.08)
+  padding: 2.5rem 2rem
+
+.login-subtitle
+  font-size: 0.8rem
+  color: $teepy-text-muted
+  text-align: center
+  margin-bottom: 1.5rem
+
+.login-error
+  font-size: 0.78rem
+  font-weight: 700
+  color: $teepy-stop
+  background-color: $teepy-warning-bg
+  border-radius: 0.6rem
+  padding: 0.6rem 0.8rem
+  margin-bottom: 1rem
+
+.login-form
+  display: flex
+  flex-direction: column
+  gap: 0.4rem
+
+.login-label
+  font-size: 0.7rem
+  font-weight: 700
+  text-transform: uppercase
+  letter-spacing: 0.05em
+  color: $teepy-text-light
+  margin-top: 0.6rem
+
+.login-input
+  border: 1px solid $teepy-border
+  background-color: $teepy-light-blue
+  color: $teepy-text
+  border-radius: 0.6rem
+  padding: 0.7rem 0.9rem
+  font-size: 0.9rem
+
+  &:focus
+    outline: none
+    border-color: $teepy-action
+    box-shadow: 0 0 0 3px $teepy-action-sec
+
+.login-submit
+  margin-top: 1.5rem
+  width: 100%
+  height: auto
+  padding: 0.85rem
+

--- a/src/templates/login.html.jinja2
+++ b/src/templates/login.html.jinja2
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Connexion | Theopy</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}?v={{ range(1, 10000) | random }}">
+</head>
+<body class="h-screen font-sans bg-gray-50 flex items-center justify-center">
+
+    <div class="login-card">
+        <h1 class="text-3xl font-black tracking-tight mb-1 text-center">
+            THEO<span class="highlight">PY</span>
+        </h1>
+        <p class="login-subtitle">Connectez-vous avec votre compte Teepy</p>
+
+        {% if error %}
+        <p class="login-error" role="alert">{{ error }}</p>
+        {% endif %}
+
+        <form method="POST" class="login-form">
+            <label for="login" class="login-label">Identifiant</label>
+            <input type="text" id="login" name="login" autocomplete="username" required
+                   class="login-input" value="{{ login or '' }}">
+
+            <label for="password" class="login-label">Mot de passe</label>
+            <input type="password" id="password" name="password" autocomplete="current-password" required
+                   class="login-input">
+
+            <button type="submit" class="btn-send login-submit">Se connecter</button>
+        </form>
+    </div>
+
+</body>
+</html>

--- a/src/templates/theopy-chat.html.jinja2
+++ b/src/templates/theopy-chat.html.jinja2
@@ -23,20 +23,15 @@
             <div id="settings-body" class="overflow-y-auto p-3 space-y-5 text-sm">
                 <section class="settings-section">
                     <h3 class="settings-section-title">Compte</h3>
-                    <p class="settings-placeholder">Authentification à venir. Aucun compte connecté pour le moment.</p>
-                </section>
-
-                <section class="settings-section">
-                    <h3 class="settings-section-title">Affichage</h3>
-                    <p class="settings-placeholder">Options d'affichage à venir.</p>
+                    <p class="settings-account-name">{{ user_name }}</p>
+                    <p class="settings-account-role">{{ user_role }}</p>
                 </section>
 
                 <section class="settings-section">
                     <h3 class="settings-section-title">Déconnexion</h3>
-                    <button type="button" class="settings-disabled-btn" disabled
-                            title="Disponible après l'implémentation de l'authentification">
+                    <a href="{{ url_for('logout') }}" class="settings-logout-btn">
                         Se déconnecter
-                    </button>
+                    </a>
                 </section>
 
                 <section class="settings-section">

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from src.app import app
+from src.app import _dispatchers, app
 from unittest.mock import AsyncMock
 from src.tests.mocks.ai_scenarios import mock_call_tool
 
@@ -10,6 +10,28 @@ def client():
     app.config["TESTING"] = True
     with app.test_client() as client:
         yield client
+
+
+@pytest.fixture
+def logged_in_client(client):
+    """A test client with an already-logged-in Theopy session (administrator),
+    for routes gated behind login_required."""
+    with client.session_transaction() as flask_session:
+        flask_session["user_id"] = 100
+        flask_session["login"] = "slamotte"
+        flask_session["name"] = "Sylvie Lamotte"
+        flask_session["role"] = "administrator"
+    return client
+
+
+@pytest.fixture(autouse=True)
+def reset_dispatchers():
+    """_dispatchers is a module-level dict keyed by user_id, shared across
+    requests in the real app - clear it between tests so a mocked dispatcher
+    from one test is never reused (and returned stale) by the next."""
+    _dispatchers.clear()
+    yield
+    _dispatchers.clear()
 
 
 @pytest.fixture(autouse=True)

--- a/src/tests/test_app_routes.py
+++ b/src/tests/test_app_routes.py
@@ -1,44 +1,59 @@
 from unittest.mock import AsyncMock, patch
 
 from src import history_store
+from src.auth import TeepyAuthError
 
 
 def test_health_endpoint(client):
-    """Test the DevOps supervision endpoint."""
+    """Test the DevOps supervision endpoint. Never gated behind login - Docker
+    needs to reach it before anyone has authenticated."""
     response = client.get("/health")
     assert response.status_code == 200
     assert response.get_json() == {"status": "healthy", "service": "Theopy-Agent"}
 
 
-def test_index_endpoint(client):
-    """Test that the main chat interface loads successfully."""
+def test_index_redirects_to_login_when_not_authenticated(client):
     response = client.get("/")
+    assert response.status_code == 302
+    assert "/login" in response.headers["Location"]
+
+
+def test_index_endpoint(logged_in_client):
+    """Test that the main chat interface loads successfully once logged in."""
+    response = logged_in_client.get("/")
     assert response.status_code == 200
     # Check that the Jinja template rendered our title
     assert b"Theopy AI" in response.data
 
 
-def test_ask_endpoint_missing_message(client):
+def test_ask_endpoint_requires_login(client):
+    response = client.post("/ask", json={"message": "Hello"})
+    assert response.status_code == 401
+    assert response.get_json() == {"error": "Not authenticated"}
+
+
+def test_ask_endpoint_missing_message(logged_in_client):
     """Test that the API correctly rejects empty requests with a 400 Bad Request."""
-    response = client.post("/ask", json={})
+    response = logged_in_client.post("/ask", json={})
     assert response.status_code == 400
     assert response.get_json() == {"error": "No message provided"}
 
 
-@patch("src.app.dispatcher")
-def test_ask_endpoint_success(mock_dispatcher, client):
+@patch("src.app.AgentDispatcher")
+def test_ask_endpoint_success(MockAgentDispatcher, logged_in_client):
     """Test the successful routing of a user message to the AI Dispatcher.
 
-    src.app now reuses a single module-level dispatcher (instead of creating a
-    fresh one per request) so its brain's conversation history persists across
-    messages - so we patch that instance directly, not the AgentDispatcher class.
+    src.app now creates one AgentDispatcher per logged-in user_id (not a
+    single shared instance), so we patch the AgentDispatcher class itself -
+    _get_dispatcher_for() will hand back MockAgentDispatcher.return_value.
     """
+    mock_dispatcher = MockAgentDispatcher.return_value
     # Because app.py wraps the call in asyncio.run(), the mock MUST be an AsyncMock
     mock_dispatcher.handle_user_input = AsyncMock(
         return_value="Here is the table of sessions you requested."
     )
 
-    response = client.post(
+    response = logged_in_client.post(
         "/ask", json={"message": "Fetch sessions for Pharmacie de la gare"}
     )
 
@@ -47,41 +62,141 @@ def test_ask_endpoint_success(mock_dispatcher, client):
         "response": "Here is the table of sessions you requested."
     }
     mock_dispatcher.handle_user_input.assert_called_once_with(
-        "Fetch sessions for Pharmacie de la gare"
+        "Fetch sessions for Pharmacie de la gare", 100, "administrator"
     )
 
 
-@patch("src.app.dispatcher")
-def test_ask_endpoint_server_error(mock_dispatcher, client):
+@patch("src.app.AgentDispatcher")
+def test_ask_endpoint_server_error(MockAgentDispatcher, logged_in_client):
     """Test the 500 Internal Server Error fallback when the AI brain crashes."""
+    mock_dispatcher = MockAgentDispatcher.return_value
     mock_dispatcher.handle_user_input = AsyncMock(
         side_effect=Exception("Simulated connection crash")
     )
 
-    response = client.post("/ask", json={"message": "Trigger a crash"})
+    response = logged_in_client.post("/ask", json={"message": "Trigger a crash"})
 
     assert response.status_code == 500
     assert response.get_json() == {"error": "I'm having trouble connecting right now."}
 
 
-def test_history_endpoint_empty_by_default(client):
+def test_history_endpoint_requires_login(client):
+    response = client.get("/history")
+    assert response.status_code == 302
+    assert "/login" in response.headers["Location"]
+
+
+def test_history_endpoint_empty_by_default(logged_in_client):
     """Test that /history returns an empty object when nothing was recorded."""
     history_store.clear()
-    response = client.get("/history")
+    response = logged_in_client.get("/history")
     assert response.status_code == 200
     assert response.get_json() == {}
 
 
-def test_history_endpoint_returns_grouped_domains(client):
+def test_history_endpoint_returns_grouped_domains(logged_in_client):
     """Test that /history exposes recorded tool calls grouped by business domain."""
     history_store.clear()
     history_store.record(
         "fetch_all_invoices_list", {"customer_name": "Gare"}, "Invoices List: ..."
     )
 
-    response = client.get("/history")
+    response = logged_in_client.get("/history")
 
     assert response.status_code == 200
     data = response.get_json()
     assert "Factures" in data
     assert data["Factures"][0]["tool_name"] == "fetch_all_invoices_list"
+
+
+def test_login_page_loads(client):
+    response = client.get("/login")
+    assert response.status_code == 200
+    assert b"Se connecter" in response.data
+
+
+def test_login_already_authenticated_redirects_to_index(logged_in_client):
+    response = logged_in_client.get("/login")
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/"
+
+
+def test_login_missing_fields(client):
+    response = client.post("/login", data={"login": "slamotte"})
+    assert response.status_code == 400
+    assert "Identifiant et mot de passe requis." in response.get_data(as_text=True)
+
+
+@patch("src.app.authenticate_with_teepy")
+def test_login_success_sets_session(mock_authenticate, client):
+    mock_authenticate.return_value = {
+        "user_id": 100,
+        "login": "slamotte",
+        "name": "Sylvie Lamotte",
+        "role": "administrator",
+    }
+
+    response = client.post("/login", data={"login": "slamotte", "password": "test"})
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/"
+    mock_authenticate.assert_called_once_with("slamotte", "test")
+
+    with client.session_transaction() as flask_session:
+        assert flask_session["user_id"] == 100
+        assert flask_session["login"] == "slamotte"
+        assert flask_session["name"] == "Sylvie Lamotte"
+        assert flask_session["role"] == "administrator"
+
+
+@patch("src.app.authenticate_with_teepy")
+def test_login_invalid_credentials(mock_authenticate, client):
+    mock_authenticate.side_effect = TeepyAuthError("Invalid credentials")
+
+    response = client.post("/login", data={"login": "slamotte", "password": "wrong"})
+
+    assert response.status_code == 401
+    assert "Invalid credentials" in response.get_data(as_text=True)
+    with client.session_transaction() as flask_session:
+        assert "user_id" not in flask_session
+
+
+@patch("src.app.authenticate_with_teepy")
+def test_login_teepy_unreachable(mock_authenticate, client):
+    import requests
+
+    mock_authenticate.side_effect = requests.ConnectionError("boom")
+
+    response = client.post("/login", data={"login": "slamotte", "password": "test"})
+
+    assert response.status_code == 503
+    assert "Impossible de contacter Teepy." in response.get_data(as_text=True)
+
+
+def test_logout_clears_session(logged_in_client):
+    response = logged_in_client.get("/logout")
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/login"
+    with logged_in_client.session_transaction() as flask_session:
+        assert "user_id" not in flask_session
+
+
+@patch("src.app.AgentDispatcher")
+def test_logout_discards_dispatcher(MockAgentDispatcher, logged_in_client):
+    """Logging out must free the per-user dispatcher (closing its MCP
+    connection and dropping conversation history), not leave it cached under
+    that user_id for whoever logs in next."""
+    from src.app import _dispatchers
+
+    mock_dispatcher = MockAgentDispatcher.return_value
+    mock_dispatcher.handle_user_input = AsyncMock(return_value="ok")
+    mock_dispatcher.shutdown = AsyncMock()
+
+    logged_in_client.post("/ask", json={"message": "hi"})
+    assert 100 in _dispatchers
+
+    logged_in_client.get("/logout")
+
+    assert 100 not in _dispatchers
+    mock_dispatcher.shutdown.assert_called_once()

--- a/src/tests/test_auth.py
+++ b/src/tests/test_auth.py
@@ -1,0 +1,62 @@
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from src.auth import TeepyAuthError, authenticate_with_teepy
+
+
+@patch("src.auth.requests.post")
+def test_authenticate_with_teepy_success(mock_post):
+    mock_post.return_value = Mock(
+        status_code=200,
+        json=Mock(
+            return_value={
+                "user_id": 100,
+                "login": "slamotte",
+                "name": "Sylvie Lamotte",
+                "role": "administrator",
+            }
+        ),
+    )
+
+    profile = authenticate_with_teepy("slamotte", "test")
+
+    assert profile == {
+        "user_id": 100,
+        "login": "slamotte",
+        "name": "Sylvie Lamotte",
+        "role": "administrator",
+    }
+    mock_post.assert_called_once()
+    _args, kwargs = mock_post.call_args
+    assert kwargs["json"] == {"login": "slamotte", "password": "test"}
+
+
+@patch("src.auth.requests.post")
+def test_authenticate_with_teepy_invalid_credentials_raises(mock_post):
+    mock_post.return_value = Mock(
+        status_code=401, json=Mock(return_value={"error": "Invalid credentials"})
+    )
+
+    with pytest.raises(TeepyAuthError, match="Invalid credentials"):
+        authenticate_with_teepy("slamotte", "wrong")
+
+
+@patch("src.auth.requests.post")
+def test_authenticate_with_teepy_employee_rejected_raises(mock_post):
+    mock_post.return_value = Mock(
+        status_code=403,
+        json=Mock(return_value={"error": "This account cannot access Theopy."}),
+    )
+
+    with pytest.raises(TeepyAuthError, match="This account cannot access Theopy."):
+        authenticate_with_teepy("mgarcia", "test")
+
+
+@patch("src.auth.requests.post")
+def test_authenticate_with_teepy_network_failure_propagates(mock_post):
+    mock_post.side_effect = requests.ConnectionError("boom")
+
+    with pytest.raises(requests.ConnectionError):
+        authenticate_with_teepy("slamotte", "test")

--- a/src/tests/test_dispatcher.py
+++ b/src/tests/test_dispatcher.py
@@ -56,9 +56,13 @@ async def test_dispatcher_handle_user_input(MockClient, mock_env):
     dispatcher.mcp_client = mock_client_instance
     dispatcher.brain = mock_brain_instance
 
-    result = await dispatcher.handle_user_input("Show me invoices.")
+    result = await dispatcher.handle_user_input(
+        "Show me invoices.", user_id=100, role="administrator"
+    )
 
     mock_client_instance.connect.assert_called_once()  # Reconnects every turn
+    assert mock_client_instance.current_user_id == 100
+    assert mock_client_instance.current_user_role == "administrator"
     mock_brain_instance.process_user_request.assert_called_once_with(
         "Show me invoices."
     )

--- a/src/tests/test_mcp_client.py
+++ b/src/tests/test_mcp_client.py
@@ -1,0 +1,86 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.mcp_client import TeepyMCPClient
+
+
+@pytest.fixture(autouse=True)
+def inject_mcp_simulator():
+    """Shadows conftest's autouse fixture of the same name: that one replaces
+    call_tool() with a scripted double, but this file tests the real
+    call_tool()/get_available_tools() implementation directly."""
+    yield
+
+
+def _fake_tool(name):
+    return SimpleNamespace(
+        name=name, description="desc", inputSchema={"type": "object", "properties": {}}
+    )
+
+
+@pytest.mark.asyncio
+async def test_call_tool_passes_theopy_user_id_as_meta():
+    client = TeepyMCPClient()
+    client._session = AsyncMock()
+    client._session.call_tool.return_value = SimpleNamespace(
+        content=[SimpleNamespace(text="Result text")]
+    )
+    client.current_user_id = 100
+
+    await client.call_tool("fetch_customer_company", {"customer_name": "Gare"})
+
+    client._session.call_tool.assert_called_once_with(
+        "fetch_customer_company",
+        {"customer_name": "Gare"},
+        meta={"theopy_user_id": 100},
+    )
+
+
+@pytest.mark.asyncio
+async def test_call_tool_with_no_user_id_sends_no_meta():
+    """Defense in depth: if a turn somehow runs with no logged-in user_id set,
+    the call must NOT silently claim an identity - Teepy denies calls with no
+    meta by default, which is the correct outcome here."""
+    client = TeepyMCPClient()
+    client._session = AsyncMock()
+    client._session.call_tool.return_value = SimpleNamespace(
+        content=[SimpleNamespace(text="Result text")]
+    )
+
+    await client.call_tool("fetch_customer_company", {"customer_name": "Gare"})
+
+    client._session.call_tool.assert_called_once_with(
+        "fetch_customer_company", {"customer_name": "Gare"}, meta=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_available_tools_filters_by_current_user_role():
+    client = TeepyMCPClient()
+    client._session = AsyncMock()
+    client._session.list_tools.return_value = SimpleNamespace(
+        tools=[
+            _fake_tool("fetch_customer_company"),
+            _fake_tool("fetch_sessions_list"),
+        ]
+    )
+    client.current_user_role = "operator"
+
+    tools = await client.get_available_tools()
+
+    assert [tool["name"] for tool in tools] == ["fetch_sessions_list"]
+
+
+@pytest.mark.asyncio
+async def test_get_available_tools_with_no_role_returns_nothing():
+    client = TeepyMCPClient()
+    client._session = AsyncMock()
+    client._session.list_tools.return_value = SimpleNamespace(
+        tools=[_fake_tool("fetch_customer_company")]
+    )
+
+    tools = await client.get_available_tools()
+
+    assert tools == []

--- a/src/tests/test_role_access.py
+++ b/src/tests/test_role_access.py
@@ -1,0 +1,47 @@
+from src.role_access import TOOL_ALLOWED_ROLES, filter_tools_for_role
+
+TOOLS = [
+    {"name": "fetch_customer_company"},
+    {"name": "fetch_sessions_list"},
+    {"name": "trigger_generate_invoices"},
+]
+
+
+def test_filter_tools_for_role_keeps_only_allowed_tools():
+    # commercial: allowed on customers, not on sessions or admin-only invoicing.
+    result = filter_tools_for_role(TOOLS, "commercial")
+
+    assert [tool["name"] for tool in result] == ["fetch_customer_company"]
+
+
+def test_filter_tools_for_role_administrator_sees_everything_mapped():
+    result = filter_tools_for_role(TOOLS, "administrator")
+
+    assert {tool["name"] for tool in result} == {
+        "fetch_customer_company",
+        "fetch_sessions_list",
+        "trigger_generate_invoices",
+    }
+
+
+def test_filter_tools_for_role_operator_gets_sessions_only():
+    result = filter_tools_for_role(TOOLS, "operator")
+
+    assert [tool["name"] for tool in result] == ["fetch_sessions_list"]
+
+
+def test_filter_tools_for_role_none_role_returns_nothing():
+    assert filter_tools_for_role(TOOLS, None) == []
+
+
+def test_filter_tools_for_role_unmapped_tool_name_is_excluded():
+    result = filter_tools_for_role(
+        [{"name": "some_future_tool_nobody_mapped_yet"}], "administrator"
+    )
+
+    assert result == []
+
+
+def test_every_mapped_tool_has_at_least_one_role():
+    for tool_name, roles in TOOL_ALLOWED_ROLES.items():
+        assert roles, f"{tool_name} maps to an empty role tuple"


### PR DESCRIPTION
**Description**
- Add a login page and `/login`, `/logout` routes. Login happens entirely in Theopy's own UI — no signups, no redirect to Teepy — and calls Teepy's new authenticate endpoint to validate real credentials.
- Gate `/`, `/ask`, and `/history` behind a logged-in session.
- `mcp_client.py` now carries the logged-in user's id on every MCP tool call, so Teepy can enforce the real caller's role server-side.
- **Bug fix surfaced by this work:** Theopy previously used a single global `AgentDispatcher` shared by every request regardless of who was logged in, meaning conversation history leaked across different users. Replaced with one dispatcher per logged-in user, torn down on logout.
- Added client-side tool-list filtering by role as a UX nicety (skip tools a role can't use rather than showing a denial message) — mirrors Teepy's role table; Teepy's own check remains the real security boundary.
- Wired the settings sidebar's "Compte" section to the real logged-in name/role and made "Déconnexion" an actual working logout link.

Screenshot:

<img width="884" height="784" alt="Screenshot 2026-07-19 at 5 34 29 PM" src="https://github.com/user-attachments/assets/794b129d-7614-4144-9a91-5090ddc5fbbe" />

close #27 