### PR TITLE
Fix scope 24h tool-call history to the logged-in user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ help:
 	@echo "Theopy Project Management Commands:"
 	@echo "  ENVIRONMENT"
 	@echo "    make install              - Install dependencies on local host"
+	@echo "    make upgrade              - Rebuild with the current requirements.txt, restart, and lint"
 	@echo "    make docker-up            - Build and start the containers"
 	@echo "    make docker-down          - Stop containers"
 	@echo "    make docker-clean         - Remove all containers, images, and volumes"
@@ -35,6 +36,14 @@ install:
 docker-up:
 	@echo "Starting system containers..."
 	$(DOCKER_COMPOSE) up --build -d
+
+upgrade:
+	@echo "Rebuilding image against the current requirements.txt..."
+	$(DOCKER_COMPOSE) build
+	@echo "Restarting containers with the upgraded image..."
+	$(DOCKER_COMPOSE) up -d
+	@echo "Linting to confirm the upgrade didn't break style compliance..."
+	$(MAKE) lint-flake8
 
 docker-down:
 	@echo "Stopping system containers..."

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Theopy
 
-Theopy is an AI-powered assistant project utilizing Gemini. This guide will help you set up your local development environment and run the system using Docker.
+Theopy is an AI-powered assistant project utilizing Gemini, built by [Kozea](https://kozea.fr). It connects to **[Teepy](https://github.com/Kozea/teepy)**, Kozea's pharmacy-management ERP, via the Model Context Protocol (MCP), letting users query and act on real Teepy data through natural language.
+
+Teepy's repository is private. A sanitized extract of my MCP/authentication contribution to Teepy - real file structure, only my own code kept - is public here: **[teepy-mcp-contribution](https://github.com/SajedehAdelia/teepy-mcp-contribution)**.
+
+This guide will help you set up your local development environment and run the system using Docker.
 
 ##  Prerequisites
 
@@ -36,9 +40,13 @@ Create a `.env` file in the root directory. This file contains API keys and the 
 ```text
 # Gemini API key from Google AI Studio
 GEMINI_API_KEY=your_gemini_key_here
+GEMINI_MODEL_ID=gemini-2.5-flash
 
 # Application port
 PORT=8000
+
+# Flask session signing key - required for login
+SECRET_KEY=generate_a_random_value_here
 
 # PostgreSQL Database Configuration (pointing to Teepy's database)
 POSTGRES_HOST=db_teepy
@@ -46,11 +54,26 @@ POSTGRES_PORT=5432
 POSTGRES_DB=database_name
 POSTGRES_USER=database_user
 POSTGRES_PASSWORD=database_password
+
+# Teepy's MCP server (tool calls) and HTTP API (login authentication) - two
+# different ports on the same Teepy container
+TEEPY_MCP_URL=http://teepy-app-1:5001/sse
+TEEPY_API_URL=http://teepy-app-1:5000
+
+# Optional: run fully local/offline with Ollama instead of Gemini
+USE_LOCAL_LLM=0
+OLLAMA_MODEL=llama3.1
 ```
 
 **Note:** Theopy is designed to work alongside **Teepy**. For the database connection to work:
 1. Both Teepy's and Theopy's Docker containers must be running.
 2. Theopy and Teepy must be connected to the same Docker network. Theopy's `docker-compose.yml` is configured to use an external network named `teepy_default`. Teepy must create and use this network.
+
+**Logging in:** Theopy has no signup - it authenticates against real Teepy
+accounts. Log in at `http://localhost:8000/login` with an existing Teepy
+login/password. Only Kozea staff roles (administrator, manager, operator,
+commercial, contractor) can access Theopy; the `employee` role (external
+pharmacy portal accounts) is rejected.
 
 ---
 
@@ -62,7 +85,7 @@ The easiest way to run the full Theopy system is via Docker. This ensures all se
 | --- | --- |
 | **Start System** | `make docker-up` |
 | **Stop System** | `make docker-down` |
-| **View Logs** | `make logs` |
+| **View Logs** | `make docker-logs` |
 | **Run Tests** | `make test` |
 | **Reset/Clean** | `make docker-clean` |
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [1.5.0] - 2026-07-19
+### Authentication & Role-Based Access Control
+* **Security:** Introduced `POST /api/theopy/authenticate` on the Teepy side, validating credentials against real production accounts. Inactive accounts and the `employee` role (external pharmacy portal users) are rejected - only Kozea staff roles can use Theopy. No signup path exists in Theopy.
+* **Security:** Replaced blanket-admin MCP context with `_resolve_real_caller()`, which re-resolves the real calling user from the database on every single tool call, using an identity carried on the MCP protocol's `meta` field (never a tool argument, so the LLM can never see or influence it). No valid identity, unknown user, or inactive user results in denial, with no fallback to admin.
+* **Added:** `requires_role()` decorator applied to all 32 existing MCP tools, each tagged with its allowed roles per business domain (invoices, customers, plannings, sessions, reminders); invoice generation restricted to `administrator` only.
+* **Added:** `src/auth.py`, `/login` and `/logout` routes, and session gating on `/`, `/ask`, and `/history` in Theopy.
+* **Added:** Client-side tool-list filtering by role (`src/role_access.py`) as a UX layer - Teepy's server-side check remains the sole authority.
+* **Fixed:** Theopy previously reused a single global `AgentDispatcher` for every request regardless of who was logged in, leaking one user's conversation history and cached tool list into another user's session. Replaced with one dispatcher per logged-in user, torn down on logout.
+* **Changed:** Settings sidebar "Compte" section now shows the real logged-in name/role; "Déconnexion" is a working logout link instead of a disabled placeholder.
+* **Tests:** Added 26 tests on the Teepy side (auth endpoint + role enforcement, verified against a real seeded database via a genuine MCP client/server round trip) and 35+ new tests on the Theopy side (auth, session gating, dispatcher isolation, role filtering).
+
+## [1.4.0] - 2026-07-18
+### Frontend UX Overhaul
+* **Added:** Settings sidebar (left) with Compte, Affichage, Déconnexion, and connected-MCP-project sections.
+* **Changed:** Moved the 24h history sidebar from left to right, alongside the new settings sidebar.
+* **Added:** Search bar in the history sidebar - searches across every domain, not just the active tab, sorted most-recent-first.
+* **Added:** Recalling a history entry now shows the original question first (faded), then the answer, in the same order as a live exchange.
+* **Added:** `frontend-tests/` with a Node built-in test-runner suite for the search/selection logic (`history-logic.js`), wired into `make check` via a new `test-js` target.
+
 ## [1.3.0] - 2026-07-07
 ### RNCP Certification Dossier & Architecture Documentation
 * **Docs:** Completely overhauled `System_Architecture.md` and `requirements.md` to formally reflect the transition to the FastMCP "Hub & Spoke" model and Server-Sent Events (SSE) data streams.

--- a/src/app.py
+++ b/src/app.py
@@ -208,8 +208,9 @@ def health():
 @app.route("/history", methods=["GET"])
 @login_required
 def get_history():
-    """Returns the last 24h of MCP tool calls, grouped by business domain."""
-    return jsonify(history_store.get_grouped()), 200
+    """Returns the current user's own last 24h of MCP tool calls, grouped by
+    business domain."""
+    return jsonify(history_store.get_grouped(session["user_id"])), 200
 
 
 if __name__ == "__main__":

--- a/src/app.py
+++ b/src/app.py
@@ -73,11 +73,25 @@ def login_required(view):
     def wrapped(*args, **kwargs):
         if "user_id" not in session:
             if request.path == "/ask":
-                return jsonify({"error": "Not authenticated"}), 401
+                return jsonify({"error": "Non authentifié."}), 401
             return redirect(url_for("login"))
         return view(*args, **kwargs)
 
     return wrapped
+
+
+# Teepy's /api/theopy/authenticate returns its error messages in English (see
+# teepy/routes/theopy_auth.py) - Theopy's UI is French-facing, so they're
+# translated here at the display boundary rather than in auth.py, keeping
+# TeepyAuthError's own contract stable and testable against Teepy's real text.
+_AUTH_ERROR_TRANSLATIONS = {
+    "Invalid credentials": "Identifiant ou mot de passe incorrect.",
+    "This account cannot access Theopy.": "Ce compte ne peut pas accéder à Theopy.",
+}
+
+
+def _translate_auth_error(message: str) -> str:
+    return _AUTH_ERROR_TRANSLATIONS.get(message, message)
 
 
 def compile_sass():
@@ -128,7 +142,11 @@ def login():
         profile = authenticate_with_teepy(login_value, password)
     except TeepyAuthError as e:
         return (
-            render_template("login.html.jinja2", error=str(e), login=login_value),
+            render_template(
+                "login.html.jinja2",
+                error=_translate_auth_error(str(e)),
+                login=login_value,
+            ),
             401,
         )
     except requests.RequestException:
@@ -163,7 +181,7 @@ def logout():
 def index():
     return render_template(
         "theopy-chat.html.jinja2",
-        title="Theopy AI",
+        title="Theopy",
         user_name=session.get("name"),
         user_login=session.get("login"),
         user_role=session.get("role"),
@@ -177,7 +195,7 @@ def ask_theopy():
     user_input = request.json.get("message")
 
     if not user_input:
-        return jsonify({"error": "No message provided"}), 400
+        return jsonify({"error": "Aucun message fourni."}), 400
 
     try:
         # Reuse this user's own dispatcher (not a fresh one) so the brain's
@@ -196,7 +214,12 @@ def ask_theopy():
         print("\n--- THEOPY CRASH REPORT ---")
         traceback.print_exc()
         print("---------------------------\n")
-        return jsonify({"error": "I'm having trouble connecting right now."}), 500
+        return (
+            jsonify(
+                {"error": "Un problème de connexion est survenu. Veuillez réessayer."}
+            ),
+            500,
+        )
 
 
 @app.route("/health", methods=["GET"])

--- a/src/app.py
+++ b/src/app.py
@@ -141,6 +141,9 @@ def login():
     try:
         profile = authenticate_with_teepy(login_value, password)
     except TeepyAuthError as e:
+        # Log failed auth attempts so they're reviewable, without
+        # ever logging the password itself.
+        logger.warning(f"Échec de la tentative de connexion={login_value!r}: {e}")
         return (
             render_template(
                 "login.html.jinja2",
@@ -149,7 +152,8 @@ def login():
             ),
             401,
         )
-    except requests.RequestException:
+    except requests.RequestException as e:
+        logger.warning(f"Échec de la tentative de connexion, Teepy indisponible: {e}")
         return (
             render_template(
                 "login.html.jinja2",
@@ -163,6 +167,11 @@ def login():
     session["login"] = profile["login"]
     session["name"] = profile["name"]
     session["role"] = profile["role"]
+
+    logger.info(
+        f"Utilisateur connecté: user_id={profile['user_id']} login={profile['login']!r} "
+        f"role={profile['role']!r}"
+    )
 
     return redirect(url_for("index"))
 
@@ -236,6 +245,13 @@ def get_history():
     return jsonify(history_store.get_grouped(session["user_id"])), 200
 
 
+def _debug_mode_enabled() -> bool:
+    """Debug mode (interactive debugger + full stack traces on
+    error) must default OFF - opt in locally via FLASK_DEBUG=1 in .env,
+    never in a real deployment."""
+    return os.getenv("FLASK_DEBUG", "0") == "1"
+
+
 if __name__ == "__main__":
     # Running on 0.0.0.0 is mandatory for Docker access
-    app.run(host="0.0.0.0", port=8000, debug=True)
+    app.run(host="0.0.0.0", port=8000, debug=_debug_mode_enabled())

--- a/src/history_store.py
+++ b/src/history_store.py
@@ -61,6 +61,10 @@ def _connect() -> sqlite3.Connection:
         conn.execute("ALTER TABLE history ADD COLUMN question TEXT")
     except sqlite3.OperationalError:
         pass  # Column already exists - safe to ignore (idempotent migration).
+    try:
+        conn.execute("ALTER TABLE history ADD COLUMN user_id INTEGER")
+    except sqlite3.OperationalError:
+        pass  # Column already exists - safe to ignore (idempotent migration).
     conn.commit()
     return conn
 
@@ -74,30 +78,51 @@ def _prune_locked() -> None:
     _conn.commit()
 
 
-def record(tool_name: str, arguments: dict, result: str, question: str = None) -> None:
+def record(
+    tool_name: str,
+    arguments: dict,
+    result: str,
+    question: str = None,
+    user_id: int = None,
+) -> None:
     """Append a tool call to the rolling 24h history. Persisted to disk, thread-safe.
     `question` is the original natural-language message that triggered this tool
-    call, so the UI can show "what you asked" alongside "what came back"."""
+    call, so the UI can show "what you asked" alongside "what came back". `user_id`
+    is the logged-in Theopy user this call belongs to - get_grouped() only ever
+    returns a caller's own entries, so different users never see each other's
+    history."""
     domain = _infer_domain(tool_name, result)
     summary = (result or "")[:160]
 
     with _LOCK:
         _conn.execute(
-            "INSERT INTO history (domain, tool_name, arguments, summary, timestamp, question) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            (domain, tool_name, json.dumps(arguments), summary, time.time(), question),
+            "INSERT INTO history (domain, tool_name, arguments, summary, timestamp, question, user_id) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                domain,
+                tool_name,
+                json.dumps(arguments),
+                summary,
+                time.time(),
+                question,
+                user_id,
+            ),
         )
         _conn.commit()
         _prune_locked()
 
 
-def get_grouped() -> dict:
-    """Return history entries grouped by domain, most recent first, pruned to 24h."""
+def get_grouped(user_id: int) -> dict:
+    """Return this user's own history entries grouped by domain, most recent
+    first, pruned to 24h. Entries recorded before user_id existed (NULL) are
+    never matched by the `= ?` comparison, so they're excluded for everyone
+    rather than attributed to the wrong person."""
     with _LOCK:
         _prune_locked()
         rows = _conn.execute(
             "SELECT id, domain, tool_name, arguments, summary, timestamp, question "
-            "FROM history ORDER BY id DESC"
+            "FROM history WHERE user_id = ? ORDER BY id DESC",
+            (user_id,),
         ).fetchall()
 
     grouped = {}

--- a/src/mcp_client.py
+++ b/src/mcp_client.py
@@ -96,7 +96,11 @@ class TeepyMCPClient:
 
         try:
             history_store.record(
-                tool_name, arguments, text, question=self.current_question
+                tool_name,
+                arguments,
+                text,
+                question=self.current_question,
+                user_id=self.current_user_id,
             )
         except Exception as e:
             # History logging is a convenience side-effect - it must never break

--- a/src/response_guard.py
+++ b/src/response_guard.py
@@ -4,9 +4,9 @@ import re
 logger = logging.getLogger(__name__)
 
 CLARIFICATION_FALLBACK = (
-    "I couldn't map that request to a specific action. Could you be more "
-    "specific — for example, which customer, date range, or type of data "
-    "you're looking for?"
+    "Je n'ai pas pu associer cette demande à une action précise. Pouvez-vous "
+    "préciser — par exemple le client, la période, ou le type de données "
+    "recherché ?"
 )
 
 # Every real MCP tool is named fetch_* or trigger_* (see mcp_server.py / ai_scenarios.py).

--- a/src/system_prompt.py
+++ b/src/system_prompt.py
@@ -2,6 +2,8 @@ THEOPY_SYSTEM_INSTRUCTION = (
     "You are Theopy, the intelligent AI assistant for the Teepy ERP system. "
     "Your job is to help managers and operators with customers, planning, "
     "invoices, reminders, and sessions. "
+    "CRITICAL: Always respond in French, regardless of the language the user "
+    "writes in - your users are French speakers. Never answer in English. "
     "Always call the relevant tool(s) to fetch real data before answering any "
     "question about specific data. "
     "When the user names a specific customer, always pass that customer's name "

--- a/src/templates/login.html.jinja2
+++ b/src/templates/login.html.jinja2
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fr">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/src/templates/theopy-chat.html.jinja2
+++ b/src/templates/theopy-chat.html.jinja2
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fr">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -50,19 +50,19 @@
                     </h1>
                     <div class="flex items-center space-x-3">
                         <div class="text-right">
-                            <p class="text-[10px] uppercase tracking-widest opacity-80 leading-none text-white">Status</p>
-                            <p class="text-sm font-bold text-white">Online</p>
+                            <p class="text-[10px] uppercase tracking-widest opacity-80 leading-none text-white">Statut</p>
+                            <p class="text-sm font-bold text-white">En ligne</p>
                         </div>
                         <div class="h-3 w-3 bg-green-400 rounded-full shadow-[0_0_8px_rgba(74,222,128,0.6)] animate-pulse"></div>
                     </div>
                 </div>
             </header>
 
-            <main id="chat-window" role="log" aria-live="polite" aria-relevant="additions" aria-label="Conversation with Theopy" class="flex-1 overflow-y-auto p-6 space-y-6 max-w-5xl mx-auto w-full">
+            <main id="chat-window" role="log" aria-live="polite" aria-relevant="additions" aria-label="Conversation avec Theopy" class="flex-1 overflow-y-auto p-6 space-y-6 max-w-5xl mx-auto w-full">
                 <div class="flex justify-start">
                     <div class="ai-bubble max-w-lg shadow-sm">
-                        <p class="font-bold text-xs uppercase tracking-widest mb-1 opacity-60">Theopy Layer</p>
-                        <p>Welcome to <strong>Theopy.</strong> I am your Backoffice assistant. How can I help you today?</p>
+                        <p class="font-bold text-xs uppercase tracking-widest mb-1 opacity-60">Theopy</p>
+                        <p>Bienvenue sur <strong>Theopy.</strong> Je suis votre assistant back-office. Comment puis-je vous aider aujourd'hui ?</p>
                     </div>
                 </div>
             </main>
@@ -71,14 +71,14 @@
                 <div class="max-w-5xl mx-auto">
                     <form id="chat-form" class="flex items-center space-x-4">
                         <div class="relative flex-1">
-                            <label for="user-input" class="sr-only">Type your message to Theopy</label>
+                            <label for="user-input" class="sr-only">Écrivez votre message à Theopy</label>
                             <input type="text" id="user-input" autocomplete="off"
-                                   aria-label="Message input"
+                                   aria-label="Champ de message"
                                    class="chat-input w-full border-2 rounded-2xl p-4 focus:outline-none transition-all"
-                                   placeholder="Type your command here...">
+                                   placeholder="Écrivez votre commande ici...">
                         </div>
-                        <button type="submit" id="send-btn" aria-label="Send message" class="btn-send flex items-center justify-center font-black text-lg shadow-lg transition-all duration-500 ease-in-out">
-                            <span class="btn-text">SEND</span>
+                        <button type="submit" id="send-btn" aria-label="Envoyer le message" class="btn-send flex items-center justify-center font-black text-lg shadow-lg transition-all duration-500 ease-in-out">
+                            <span class="btn-text">ENVOYER</span>
                         </button>
                     </form>
                 </div>
@@ -141,7 +141,7 @@
 
                 const header = document.createElement('p');
                 header.className = "font-bold text-xs uppercase tracking-widest mb-2 opacity-60";
-                header.innerText = "Theopy Layer";
+                header.innerText = "Theopy";
                 bubble.prepend(header);
             }
 
@@ -329,12 +329,12 @@
                 const data = await res.json();
 
                 if(data.error) {
-                    appendMessage("Theopy Error: " + data.error, false);
+                    appendMessage("Erreur Theopy : " + data.error, false);
                 } else {
                     appendMessage(data.response, false);
                 }
             } catch (err) {
-                appendMessage("Theopy Error: Connection lost.", false);
+                appendMessage("Erreur Theopy : connexion perdue.", false);
             } finally {
                 // --- UI ANIMATION: TURN OFF SIRI MODE ---
                 sendBtn.classList.remove('thinking-mode');

--- a/src/tests/test_app_routes.py
+++ b/src/tests/test_app_routes.py
@@ -98,7 +98,10 @@ def test_history_endpoint_returns_grouped_domains(logged_in_client):
     """Test that /history exposes recorded tool calls grouped by business domain."""
     history_store.clear()
     history_store.record(
-        "fetch_all_invoices_list", {"customer_name": "Gare"}, "Invoices List: ..."
+        "fetch_all_invoices_list",
+        {"customer_name": "Gare"},
+        "Invoices List: ...",
+        user_id=100,
     )
 
     response = logged_in_client.get("/history")
@@ -107,6 +110,20 @@ def test_history_endpoint_returns_grouped_domains(logged_in_client):
     data = response.get_json()
     assert "Factures" in data
     assert data["Factures"][0]["tool_name"] == "fetch_all_invoices_list"
+
+
+def test_history_endpoint_does_not_return_another_users_entries(logged_in_client):
+    """logged_in_client is user_id=100 - a call recorded under a different
+    user_id must never show up in this user's /history."""
+    history_store.clear()
+    history_store.record(
+        "fetch_all_invoices_list", {}, "someone else's invoice call", user_id=999
+    )
+
+    response = logged_in_client.get("/history")
+
+    assert response.status_code == 200
+    assert response.get_json() == {}
 
 
 def test_login_page_loads(client):

--- a/src/tests/test_app_routes.py
+++ b/src/tests/test_app_routes.py
@@ -23,20 +23,20 @@ def test_index_endpoint(logged_in_client):
     response = logged_in_client.get("/")
     assert response.status_code == 200
     # Check that the Jinja template rendered our title
-    assert b"Theopy AI" in response.data
+    assert b"Theopy" in response.data
 
 
 def test_ask_endpoint_requires_login(client):
     response = client.post("/ask", json={"message": "Hello"})
     assert response.status_code == 401
-    assert response.get_json() == {"error": "Not authenticated"}
+    assert response.get_json() == {"error": "Non authentifié."}
 
 
 def test_ask_endpoint_missing_message(logged_in_client):
     """Test that the API correctly rejects empty requests with a 400 Bad Request."""
     response = logged_in_client.post("/ask", json={})
     assert response.status_code == 400
-    assert response.get_json() == {"error": "No message provided"}
+    assert response.get_json() == {"error": "Aucun message fourni."}
 
 
 @patch("src.app.AgentDispatcher")
@@ -77,7 +77,9 @@ def test_ask_endpoint_server_error(MockAgentDispatcher, logged_in_client):
     response = logged_in_client.post("/ask", json={"message": "Trigger a crash"})
 
     assert response.status_code == 500
-    assert response.get_json() == {"error": "I'm having trouble connecting right now."}
+    assert response.get_json() == {
+        "error": "Un problème de connexion est survenu. Veuillez réessayer."
+    }
 
 
 def test_history_endpoint_requires_login(client):
@@ -173,9 +175,34 @@ def test_login_invalid_credentials(mock_authenticate, client):
     response = client.post("/login", data={"login": "slamotte", "password": "wrong"})
 
     assert response.status_code == 401
-    assert "Invalid credentials" in response.get_data(as_text=True)
+    # Teepy's raw error is English - the login page must show the French
+    # translation instead, never the untranslated string.
+    assert "Identifiant ou mot de passe incorrect." in response.get_data(as_text=True)
+    assert "Invalid credentials" not in response.get_data(as_text=True)
     with client.session_transaction() as flask_session:
         assert "user_id" not in flask_session
+
+
+@patch("src.app.authenticate_with_teepy")
+def test_login_employee_role_rejected_shows_french_message(mock_authenticate, client):
+    mock_authenticate.side_effect = TeepyAuthError("This account cannot access Theopy.")
+
+    response = client.post("/login", data={"login": "mgarcia", "password": "test"})
+
+    assert response.status_code == 401
+    assert "Ce compte ne peut pas accéder à Theopy." in response.get_data(as_text=True)
+
+
+@patch("src.app.authenticate_with_teepy")
+def test_login_unmapped_teepy_error_passes_through_unchanged(mock_authenticate, client):
+    """Defense in depth: an error message Teepy might add later, not yet in
+    the translation table, should still reach the user rather than vanish."""
+    mock_authenticate.side_effect = TeepyAuthError("Some new error Teepy added")
+
+    response = client.post("/login", data={"login": "slamotte", "password": "test"})
+
+    assert response.status_code == 401
+    assert "Some new error Teepy added" in response.get_data(as_text=True)
 
 
 @patch("src.app.authenticate_with_teepy")

--- a/src/tests/test_app_routes.py
+++ b/src/tests/test_app_routes.py
@@ -228,9 +228,6 @@ def test_logout_clears_session(logged_in_client):
 
 @patch("src.app.AgentDispatcher")
 def test_logout_discards_dispatcher(MockAgentDispatcher, logged_in_client):
-    """Logging out must free the per-user dispatcher (closing its MCP
-    connection and dropping conversation history), not leave it cached under
-    that user_id for whoever logs in next."""
     from src.app import _dispatchers
 
     mock_dispatcher = MockAgentDispatcher.return_value
@@ -244,3 +241,54 @@ def test_logout_discards_dispatcher(MockAgentDispatcher, logged_in_client):
 
     assert 100 not in _dispatchers
     mock_dispatcher.shutdown.assert_called_once()
+
+
+def test_debug_mode_defaults_to_off(monkeypatch):
+    from src.app import _debug_mode_enabled
+
+    monkeypatch.delenv("FLASK_DEBUG", raising=False)
+    assert _debug_mode_enabled() is False
+
+
+def test_debug_mode_can_be_enabled_via_env_var(monkeypatch):
+    from src.app import _debug_mode_enabled
+
+    monkeypatch.setenv("FLASK_DEBUG", "1")
+    assert _debug_mode_enabled() is True
+
+
+@patch("src.app.authenticate_with_teepy")
+def test_login_success_is_logged(mock_authenticate, client, caplog):
+    mock_authenticate.return_value = {
+        "user_id": 100,
+        "login": "slamotte",
+        "name": "Sylvie Lamotte",
+        "role": "administrator",
+    }
+
+    with caplog.at_level("INFO"):
+        client.post("/login", data={"login": "slamotte", "password": "test"})
+
+    assert any(
+        "Utilisateur connecté" in record.message and "slamotte" in record.message
+        for record in caplog.records
+    )
+
+
+@patch("src.app.authenticate_with_teepy")
+def test_login_failure_is_logged_without_the_password(
+    mock_authenticate, client, caplog
+):
+    mock_authenticate.side_effect = TeepyAuthError("Invalid credentials")
+
+    with caplog.at_level("WARNING"):
+        client.post(
+            "/login", data={"login": "slamotte", "password": "super-secret-value"}
+        )
+
+    warning_messages = [record.message for record in caplog.records]
+    assert any(
+        "Échec de la tentative de connexion" in msg and "slamotte" in msg
+        for msg in warning_messages
+    )
+    assert not any("super-secret-value" in msg for msg in warning_messages)

--- a/src/tests/test_history_store.py
+++ b/src/tests/test_history_store.py
@@ -1,5 +1,8 @@
 from src import history_store
 
+USER_A = 100
+USER_B = 101
+
 
 def setup_function():
     """Ensure each test starts from a clean, empty history."""
@@ -8,16 +11,28 @@ def setup_function():
 
 def test_record_infers_domain_from_tool_name():
     history_store.record(
-        "fetch_all_invoices_list", {"customer_name": "Gare"}, "Invoices List: ..."
+        "fetch_all_invoices_list",
+        {"customer_name": "Gare"},
+        "Invoices List: ...",
+        user_id=USER_A,
     )
     history_store.record(
-        "fetch_planning_dashboard_customers", {}, "Customer Dashboard Summary"
+        "fetch_planning_dashboard_customers",
+        {},
+        "Customer Dashboard Summary",
+        user_id=USER_A,
     )
-    history_store.record("fetch_reminders_list", {}, "Reminders List: ...")
-    history_store.record("trigger_start_session", {}, "Success: Session 999 started")
-    history_store.record("unknown_diagnostic_tool", {}, "Mocked response")
+    history_store.record(
+        "fetch_reminders_list", {}, "Reminders List: ...", user_id=USER_A
+    )
+    history_store.record(
+        "trigger_start_session", {}, "Success: Session 999 started", user_id=USER_A
+    )
+    history_store.record(
+        "unknown_diagnostic_tool", {}, "Mocked response", user_id=USER_A
+    )
 
-    grouped = history_store.get_grouped()
+    grouped = history_store.get_grouped(USER_A)
 
     assert "Factures" in grouped
     assert "Plannings" in grouped
@@ -27,10 +42,10 @@ def test_record_infers_domain_from_tool_name():
 
 
 def test_get_grouped_returns_most_recent_first():
-    history_store.record("fetch_all_invoices_list", {}, "first call")
-    history_store.record("fetch_all_invoices_list", {}, "second call")
+    history_store.record("fetch_all_invoices_list", {}, "first call", user_id=USER_A)
+    history_store.record("fetch_all_invoices_list", {}, "second call", user_id=USER_A)
 
-    grouped = history_store.get_grouped()
+    grouped = history_store.get_grouped(USER_A)
 
     assert [entry["summary"] for entry in grouped["Factures"]] == [
         "second call",
@@ -40,21 +55,28 @@ def test_get_grouped_returns_most_recent_first():
 
 def test_summary_is_truncated_to_160_chars():
     long_result = "x" * 500
-    history_store.record("fetch_all_invoices_list", {}, long_result)
+    history_store.record("fetch_all_invoices_list", {}, long_result, user_id=USER_A)
 
-    grouped = history_store.get_grouped()
+    grouped = history_store.get_grouped(USER_A)
 
     assert len(grouped["Factures"][0]["summary"]) == 160
 
 
 def test_empty_or_error_result_is_filed_under_autre_regardless_of_tool():
     history_store.record(
-        "fetch_sessions_list", {}, "No sessions found for this criteria."
+        "fetch_sessions_list",
+        {},
+        "No sessions found for this criteria.",
+        user_id=USER_A,
     )
-    history_store.record("fetch_all_invoices_list", {}, "No data returned.")
-    history_store.record("trigger_start_session", {}, "Error: Session not found.")
+    history_store.record(
+        "fetch_all_invoices_list", {}, "No data returned.", user_id=USER_A
+    )
+    history_store.record(
+        "trigger_start_session", {}, "Error: Session not found.", user_id=USER_A
+    )
 
-    grouped = history_store.get_grouped()
+    grouped = history_store.get_grouped(USER_A)
 
     assert "Sessions" not in grouped
     assert "Factures" not in grouped
@@ -67,9 +89,10 @@ def test_record_stores_the_originating_question():
         {"customer_name": "Marcel Dumont"},
         "Customer: Pharmacie de la Gare | Holder: Marcel Dumont",
         question="which company does Marcel Dumont belong to?",
+        user_id=USER_A,
     )
 
-    grouped = history_store.get_grouped()
+    grouped = history_store.get_grouped(USER_A)
 
     assert (
         grouped["Autre"][0]["question"] == "which company does Marcel Dumont belong to?"
@@ -78,9 +101,11 @@ def test_record_stores_the_originating_question():
 
 def test_record_without_question_defaults_to_none():
     """Backwards compatible: existing callers not passing question shouldn't break."""
-    history_store.record("fetch_all_invoices_list", {}, "Invoices List: ...")
+    history_store.record(
+        "fetch_all_invoices_list", {}, "Invoices List: ...", user_id=USER_A
+    )
 
-    grouped = history_store.get_grouped()
+    grouped = history_store.get_grouped(USER_A)
 
     assert grouped["Factures"][0]["question"] is None
 
@@ -89,13 +114,44 @@ def test_entries_older_than_24h_are_pruned(monkeypatch):
     fake_now = [1_000_000.0]
     monkeypatch.setattr(history_store.time, "time", lambda: fake_now[0])
 
-    history_store.record("fetch_all_invoices_list", {}, "old entry")
+    history_store.record("fetch_all_invoices_list", {}, "old entry", user_id=USER_A)
 
     # Advance the clock by 24h and 1 second.
     fake_now[0] += history_store.RETENTION_SECONDS + 1
-    history_store.record("fetch_reminders_list", {}, "fresh entry")
+    history_store.record("fetch_reminders_list", {}, "fresh entry", user_id=USER_A)
 
-    grouped = history_store.get_grouped()
+    grouped = history_store.get_grouped(USER_A)
 
     assert "Factures" not in grouped
     assert grouped["Relances"][0]["summary"] == "fresh entry"
+
+
+def test_get_grouped_only_returns_the_requesting_users_own_entries():
+    history_store.record(
+        "fetch_all_invoices_list", {}, "user A's invoice call", user_id=USER_A
+    )
+    history_store.record(
+        "fetch_all_invoices_list", {}, "user B's invoice call", user_id=USER_B
+    )
+
+    grouped_a = history_store.get_grouped(USER_A)
+    grouped_b = history_store.get_grouped(USER_B)
+
+    assert [entry["summary"] for entry in grouped_a["Factures"]] == [
+        "user A's invoice call"
+    ]
+    assert [entry["summary"] for entry in grouped_b["Factures"]] == [
+        "user B's invoice call"
+    ]
+
+
+def test_get_grouped_excludes_entries_recorded_without_a_user_id():
+    """Entries recorded before this migration (user_id=NULL) must not be shown
+    to anyone - not attributed to the wrong person."""
+    history_store.record(
+        "fetch_all_invoices_list", {}, "pre-migration entry", user_id=None
+    )
+
+    grouped = history_store.get_grouped(USER_A)
+
+    assert grouped == {}


### PR DESCRIPTION
**Description**

- `/history` (and the underlying `history_store.py`) previously recorded and returned every MCP tool call from every session, with no notion of who made it. Since #27 added per-user login, this meant any two logged-in users could see each other's tool-call history and the business questions that triggered them — a real gap in the RBAC work, not just a cosmetic one.
- Added an idempotent `user_id` column migration to the SQLite store (same pattern already used for the `question` column).
- `mcp_client.py` now threads `self.current_user_id` into `history_store.record()`, reusing the identity that's already carried on every MCP call.
- `get_grouped()` now requires a `user_id` and only returns that user's own entries. Rows recorded before this migration (`user_id = NULL`) are excluded for everyone rather than guessed at — `WHERE user_id = ?` never matches `NULL`.
- `/history` now passes the logged-in session's `user_id`.

Screenshots:

Sylvie Lamotte's login:
<img width="1461" height="530" alt="Screenshot 2026-07-19 at 6 39 05 PM" src="https://github.com/user-attachments/assets/23d26b26-56cb-4c6b-8431-8e68843b6fd6" />

Mathieu Onésime's login:
<img width="1465" height="614" alt="Screenshot 2026-07-19 at 6 39 25 PM" src="https://github.com/user-attachments/assets/f9609fdd-8bd5-46e4-82ab-a03260c5691f" />


close #30 